### PR TITLE
Make display() method a context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,20 +216,16 @@ GF([[231, 157, 137,  89, 159,  82, 194, 164,  70, 175],
 Display field elements as integers or polynomials.
 
 ```python
->>> x
+>>> print(x)
 GF([118,  49, 122, 166, 136, 118,  53,  19, 233, 119], order=2^8)
 
-# Set the display mode to represent GF(p^m) field elements as polynomials over GF(p)[x].
->>> GF256.display("poly")
-
->>> x
+# Temporarily set the display mode to represent GF(p^m) field elements as polynomials over GF(p)[x].
+>>> with GF256.display("poly"):
+...     print(x)
 GF([x^6 + x^5 + x^4 + x^2 + x, x^5 + x^4 + 1, x^6 + x^5 + x^4 + x^3 + x,
     x^7 + x^5 + x^2 + x, x^7 + x^3, x^6 + x^5 + x^4 + x^2 + x,
     x^5 + x^4 + x^2 + 1, x^4 + x + 1, x^7 + x^6 + x^5 + x^3 + 1,
     x^6 + x^5 + x^4 + x^2 + x + 1], order=2^8)
-
-# Reset the display settings to the default of "int"
-GF256.display()
 ```
 
 ### Galois field polynomial construction

--- a/docs/pages/basic_usage.rst
+++ b/docs/pages/basic_usage.rst
@@ -119,14 +119,11 @@ Display field elements as integers or polynomials.
 
 .. ipython:: python
 
-   x
+   print(x)
 
-   # Set the display mode to represent GF(p^m) field elements as polynomials over GF(p)[x].
-   GF256.display("poly")
-   x
-
-   # Reset the display settings to the default of "int"
-   GF256.display()
+   # Temporarily set the display mode to represent GF(p^m) field elements as polynomials over GF(p)[x].
+   with GF256.display("poly"):
+      print(x)
 
 Galois field polynomial construction
 ------------------------------------

--- a/docs/pages/tutorials/constructing_fields.rst
+++ b/docs/pages/tutorials/constructing_fields.rst
@@ -144,3 +144,17 @@ as degree-3 polynomials in :math:`\mathrm{GF}(2)[x]`, i.e. :math:`\{0, 1, x, x+1
 
    # Reset the display mode to the default
    GF.display(); a
+
+The :obj:`galois.GF.display` method can be called as a context manager.
+
+.. ipython:: python
+
+   # The original display mode
+   print(a)
+
+   # The new display context
+   with GF.display("poly"):
+      print(a)
+
+   # Returns to the original display mode
+   print(a)

--- a/docs/pages/tutorials/extremely_large_fields.rst
+++ b/docs/pages/tutorials/extremely_large_fields.rst
@@ -44,3 +44,6 @@ Large GF(2^m) fields
    b
    a + b
    a * b
+
+   # Reset the display mode
+   GF.display()

--- a/tests/fields/test_methods.py
+++ b/tests/fields/test_methods.py
@@ -1,0 +1,47 @@
+"""
+A pytest module to test methods of Galois field array classes.
+"""
+import random
+
+import numpy as np
+import pytest
+
+import galois
+
+
+def test_display_method():
+    GF = galois.GF_factory(2, 3)
+    a = GF([1, 5, 2])
+    assert str(a) == "GF([1, 5, 2], order=2^3)"
+    GF.display("poly")
+    assert str(a) == "GF([1, x^2 + 1, x], order=2^3)"
+    GF.display()
+    assert str(a) == "GF([1, 5, 2], order=2^3)"
+
+
+def test_display_context_manager():
+    GF = galois.GF_factory(2, 3)
+    a = GF([1, 5, 2])
+    assert str(a) == "GF([1, 5, 2], order=2^3)"
+    with GF.display("poly"):
+        assert str(a) == "GF([1, x^2 + 1, x], order=2^3)"
+    assert str(a) == "GF([1, 5, 2], order=2^3)"
+
+
+def test_display_poly_var_method():
+    GF = galois.GF_factory(2, 3)
+    a = GF([1, 5, 2])
+    assert str(a) == "GF([1, 5, 2], order=2^3)"
+    GF.display("poly", "r")
+    assert str(a) == "GF([1, r^2 + 1, r], order=2^3)"
+    GF.display()
+    assert str(a) == "GF([1, 5, 2], order=2^3)"
+
+
+def test_display_poly_var_context_manager():
+    GF = galois.GF_factory(2, 3)
+    a = GF([1, 5, 2])
+    assert str(a) == "GF([1, 5, 2], order=2^3)"
+    with GF.display("poly", "r"):
+        assert str(a) == "GF([1, r^2 + 1, r], order=2^3)"
+    assert str(a) == "GF([1, 5, 2], order=2^3)"


### PR DESCRIPTION
```python
In [1]: import galois                                                                                                        

In [2]: GF = galois.GF_factory(2, 8)                                                                                         

In [3]: a = GF.Random(10)                                                                                                    

In [4]: print(a)                                                                                                                    
GF([143,   5,  38,   1, 228, 119, 175, 167, 212, 130], order=2^8)

In [6]: with GF.display("poly"): 
   ...:     print(a) 
   ...:                                                                                                                      
GF([x^7 + x^3 + x^2 + x + 1, x^2 + 1, x^5 + x^2 + x, 1,
    x^7 + x^6 + x^5 + x^2, x^6 + x^5 + x^4 + x^2 + x + 1,
    x^7 + x^5 + x^3 + x^2 + x + 1, x^7 + x^5 + x^2 + x + 1,
    x^7 + x^6 + x^4 + x^2, x^7 + x], order=2^8)

In [7]: print(a)                                                                                                             
GF([143,   5,  38,   1, 228, 119, 175, 167, 212, 130], order=2^8)
```