### PR TITLE
Optimize load times with JIT on-demand

### DIFF
--- a/galois/field/meta.py
+++ b/galois/field/meta.py
@@ -80,7 +80,7 @@ class FieldMeta(Meta, FieldUfunc, FieldFunc):
         if element == 0:
             s = "0"
         else:
-            power = cls._ufuncs["log"](element)
+            power = cls._ufunc_log()(element)
             if power > 1:
                 s = f"α^{power}"
             elif power == 1:

--- a/galois/group/meta_func.py
+++ b/galois/group/meta_func.py
@@ -9,6 +9,3 @@ class GroupFunc(Func):
 
     _overridden_functions = {}
     _overridden_linalg_functions = {}
-
-    def _compile_funcs(cls, target):
-        return

--- a/galois/group/meta_ufunc_add.py
+++ b/galois/group/meta_ufunc_add.py
@@ -14,11 +14,11 @@ class AdditiveGroupUfunc(Ufunc):
     # pylint: disable=no-value-for-parameter
 
     _overridden_ufuncs = {
-        np.add: "_ufunc_add",
-        np.negative: "_ufunc_negative",
-        np.power: "_ufunc_power",
-        np.square: "_ufunc_square",
-        # np.log: "_ufunc_log",
+        np.add: "_ufunc_routine_add",
+        np.negative: "_ufunc_routine_negative",
+        np.power: "_ufunc_routine_power",
+        np.square: "_ufunc_routine_square",
+        # np.log: "_ufunc_routine_log",
     }
 
     _unsupported_ufuncs = Ufunc._unsupported_ufuncs + [
@@ -31,24 +31,34 @@ class AdditiveGroupUfunc(Ufunc):
         np.matmul,
     ]
 
-    def _compile_ufuncs(cls, target):
+    ###############################################################################
+    # Compile general-purpose calculate functions
+    ###############################################################################
+
+    def _compile_power_calculate(cls):
         global MODULUS, ORDER
+        MODULUS = cls.modulus
+        ORDER = cls.order
+        kwargs = {"nopython": True, "target": cls.ufunc_target} if cls.ufunc_target != "cuda" else {"target": cls.ufunc_target}
+        return numba.vectorize(["int64(int64, int64)"], **kwargs)(_power_calculate)
 
-        if cls._ufunc_mode == "jit-calculate":
-            MODULUS = cls.modulus
-            ORDER = cls.order
-            kwargs = {"nopython": True, "target": target} if target != "cuda" else {"target": target}
-            cls._ufuncs["power"] = numba.vectorize(["int64(int64, int64)"], **kwargs)(_power_calculate)
-            # cls._ufuncs["log"] = numba.vectorize(["int64(int64, int64)"], **kwargs)(_log_calculate)
+    ###############################################################################
+    # Individual ufuncs, compiled on-demand
+    ###############################################################################
 
-        else:
-            cls._ufuncs["power"] = np.frompyfunc(cls._power_python, 2, 1)
+    def _ufunc_power(cls):
+        if cls._ufuncs.get("power", None) is None:
+            if cls.ufunc_mode == "jit-calculate":
+                cls._ufuncs["power"] = cls._compile_power_calculate()
+            else:
+                cls._ufuncs["power"] = np.frompyfunc(cls._power_python, 2, 1)
+        return cls._ufuncs["power"]
 
     ###############################################################################
     # Ufunc routines
     ###############################################################################
 
-    def _ufunc_add(cls, ufunc, method, inputs, kwargs, meta):
+    def _ufunc_routine_add(cls, ufunc, method, inputs, kwargs, meta):
         cls._verify_operands_in_same_field(ufunc, inputs, meta)
         inputs, kwargs = cls._view_inputs_as_ndarray(inputs, kwargs)
         output = getattr(np.add, method)(*inputs, **kwargs)
@@ -56,29 +66,29 @@ class AdditiveGroupUfunc(Ufunc):
         output = cls._view_output_as_field(output, meta["field"], meta["dtype"])
         return output
 
-    def _ufunc_negative(cls, ufunc, method, inputs, kwargs, meta):  # pylint: disable=unused-argument
+    def _ufunc_routine_negative(cls, ufunc, method, inputs, kwargs, meta):  # pylint: disable=unused-argument
         cls._verify_unary_method_not_reduction(ufunc, method)
         inputs, kwargs = cls._view_inputs_as_ndarray(inputs, kwargs)
         output = np.mod(cls.modulus - inputs[0], cls.modulus)
         output = cls._view_output_as_field(output, meta["field"], meta["dtype"])
         return output
 
-    def _ufunc_power(cls, ufunc, method, inputs, kwargs, meta):
+    def _ufunc_routine_power(cls, ufunc, method, inputs, kwargs, meta):
         cls._verify_binary_method_not_reduction(ufunc, method)
         cls._verify_operands_first_field_second_int(ufunc, inputs, meta)
-        output = getattr(cls._ufuncs["power"], method)(*inputs, **kwargs)
+        output = getattr(cls._ufunc_power(), method)(*inputs, **kwargs)
         output = cls._view_output_as_field(output, meta["field"], meta["dtype"])
         return output
 
-    def _ufunc_square(cls, ufunc, method, inputs, kwargs, meta):  # pylint: disable=unused-argument
+    def _ufunc_routine_square(cls, ufunc, method, inputs, kwargs, meta):  # pylint: disable=unused-argument
         inputs = list(inputs) + [2]
-        return cls._ufunc_power(ufunc, method, inputs, kwargs, meta)
+        return cls._ufunc_power()(ufunc, method, inputs, kwargs, meta)
 
-    # def _ufunc_log(cls, ufunc, method, inputs, kwargs, meta):  # pylint: disable=unused-argument
+    # def _ufunc_routine_log(cls, ufunc, method, inputs, kwargs, meta):  # pylint: disable=unused-argument
     #     cls._verify_method_only_call(ufunc, method)
     #     # base = cls.generator if len(inputs) == 1 else inputs[1]
     #     # base = np.broadcast_to(base, inputs[0].shape)
-    #     output = getattr(cls._ufuncs["log"], method)(*inputs, **kwargs)
+    #     output = getattr(cls._ufunc_log(), method)(*inputs, **kwargs)
     #     return output
 
     ###############################################################################

--- a/galois/meta.py
+++ b/galois/meta.py
@@ -65,8 +65,8 @@ class Meta(Ufunc, Func):
 
         cls._ufunc_mode = mode
         cls._ufunc_target = target
-        cls._compile_ufuncs(target)
-        cls._compile_funcs(target)
+        cls._compile_ufuncs()
+        cls._compile_funcs()
 
     ###############################################################################
     # Array display methods

--- a/galois/meta_func.py
+++ b/galois/meta_func.py
@@ -39,5 +39,9 @@ class Func(type):
     _overridden_functions = {}
     _overridden_linalg_functions = {}
 
-    def _compile_funcs(cls, target):
-        raise NotImplementedError
+    def __init__(cls, name, bases, namespace, **kwargs):
+        super().__init__(name, bases, namespace, **kwargs)
+        cls._funcs = {}
+
+    def _compile_funcs(cls):
+        cls._funcs = {}  # Reset the dictionary so each func will get recompiled

--- a/galois/meta_ufunc.py
+++ b/galois/meta_ufunc.py
@@ -49,8 +49,8 @@ class Ufunc(type):
         super().__init__(name, bases, namespace, **kwargs)
         cls._ufuncs = {}
 
-    def _compile_ufuncs(cls, target):
-        raise NotImplementedError
+    def _compile_ufuncs(cls):
+        cls._ufuncs = {}  # Reset the dictionary so each ufunc will get recompiled
 
     ###############################################################################
     # Input/output conversion functions


### PR DESCRIPTION
Don't compile all ufuncs and JIT functions at class build time, but at first-use time.

This prevents users from paying a load penalty for ufuncs or functions they never use. For those ufuncs/functions they do use, there is a slight delay (~100 ms) in the first call to JIT compile and then subsequent calls are fast. Even if all ufuncs/functions are used, this distributes the compile/load time.

Before:
```python
In [1]: %time import galois
CPU times: user 1.71 s, sys: 688 ms, total: 2.4 s
Wall time: 1.25 s

In [2]: %time GF = galois.GF(2**8)
CPU times: user 935 ms, sys: 11.6 ms, total: 946 ms
Wall time: 953 ms

In [3]: a = GF.Random(10)

In [4]: b = GF.Random(10)

In [5]: %time a / b
CPU times: user 544 µs, sys: 123 µs, total: 667 µs
Wall time: 629 µs
Out[5]: GF([132, 116,  38, 245,  71,  63,  23,  58, 247, 159], order=2^8)

In [6]: %time a / b
CPU times: user 332 µs, sys: 75 µs, total: 407 µs
Wall time: 344 µs
Out[6]: GF([132, 116,  38, 245,  71,  63,  23,  58, 247, 159], order=2^8)

In [7]: %time a / b
CPU times: user 260 µs, sys: 59 µs, total: 319 µs
Wall time: 217 µs
Out[7]: GF([132, 116,  38, 245,  71,  63,  23,  58, 247, 159], order=2^8)
```

After:
```python
In [1]: %time import galois                                                                     
CPU times: user 1.22 s, sys: 702 ms, total: 1.92 s
Wall time: 684 ms

In [2]: %time GF = galois.GF(2**8)                                                              
CPU times: user 239 ms, sys: 683 µs, total: 240 ms
Wall time: 239 ms

In [3]: a = GF.Random(10)                                                                       

In [4]: b = GF.Random(10, low=1)                                                                

In [5]: %time a / b                                                                             
CPU times: user 96.2 ms, sys: 0 ns, total: 96.2 ms
Wall time: 95 ms
Out[5]: GF([  3, 129, 103, 253, 116, 198, 173, 109, 234, 165], order=2^8)

In [6]: %time a / b                                                                             
CPU times: user 407 µs, sys: 128 µs, total: 535 µs
Wall time: 462 µs
Out[6]: GF([  3, 129, 103, 253, 116, 198, 173, 109, 234, 165], order=2^8)

In [7]: %time a / b                                                                             
CPU times: user 474 µs, sys: 146 µs, total: 620 µs
Wall time: 552 µs
Out[7]: GF([  3, 129, 103, 253, 116, 198, 173, 109, 234, 165], order=2^8)
```