### PR TITLE
Clean up `galois.GF` arguments

### DIFF
--- a/galois/field/factory.py
+++ b/galois/field/factory.py
@@ -20,27 +20,31 @@ def GF(order, irreducible_poly=None, primitive_element=None, verify=True, mode="
     ----------
     order : int
         The order :math:`p^m` of the field :math:`\\mathrm{GF}(p^m)`. The order must be a prime power.
-    irreducible_poly : int, galois.Poly, optional
+    irreducible_poly : int, tuple, list, numpy.ndarray, galois.Poly, optional
         Optionally specify an irreducible polynomial of degree :math:`m` over :math:`\\mathrm{GF}(p)` that will
         define the Galois field arithmetic. An integer may be provided, which is the integer representation of the
-        irreducible polynomial. Default is `None` which uses the Conway polynomial :math:`C_{p,m}` obtained from :func:`galois.conway_poly`.
-    primitive_element : int, galois.Poly, optional
+        irreducible polynomial. A tuple, list, or ndarray may be provided, which represents the polynomial coefficients in
+        degree-descending order. The default is `None` which uses the Conway polynomial :math:`C_{p,m}` obtained from :func:`galois.conway_poly`.
+    primitive_element : int, tuple, list, numpy.ndarray, galois.Poly, optional
         Optionally specify a primitive element of the field :math:`\\mathrm{GF}(p^m)`. A primitive element is a generator of
         the multiplicative group of the field. For prime fields :math:`\\mathrm{GF}(p)`, the primitive element must be an integer
         and is a primitive root modulo :math:`p`. For extension fields :math:`\\mathrm{GF}(p^m)`, the primitive element is a polynomial
-        of degree less than :math:`m` over :math:`\\mathrm{GF}(p)` or its integer representation. The default is `None` which uses
-        :obj:`galois.primitive_root(p)` for prime fields and :obj:`galois.primitive_element(irreducible_poly)` for extension fields.
+        of degree less than :math:`m` over :math:`\\mathrm{GF}(p)`. An integer may be provided, which is the integer representation of the polynomial.
+        A tuple, list, or ndarray may be provided, which represents the polynomial coefficients in degree-descending order. The default is `None`
+        which uses :obj:`galois.primitive_root(p)` for prime fields and :obj:`galois.primitive_element(irreducible_poly)` for extension fields.
     verify : bool, optional
         Indicates whether to verify that the specified irreducible polynomial is in fact irreducible and that the specified primitive element
-        is in fact a generator of the multiplicative group. The default is `True`. For large fields, irreducible polynomials that are already
-        known to be irreducible (and may take a long time to verify), this argument can be set to `False`.
+        is in fact a generator of the multiplicative group. The default is `True`. For large fields and irreducible polynomials that are already
+        known to be irreducible (and may take a long time to verify), this argument can be set to `False`. If the default irreducible polynomial
+        and primitive element are used, no verification is performed because the defaults are already guaranteed to be irreducible and a multiplicative
+        generator, respectively.
     mode : str, optional
         The type of field computation, either `"auto"`, `"jit-lookup"`, or `"jit-calculate"`. The default is `"auto"`.
         The "jit-lookup" mode will use Zech log, log, and anti-log lookup tables for efficient calculation. The "jit-calculate"
         mode will not store any lookup tables, but instead perform field arithmetic on the fly. The "jit-calculate" mode is
         designed for large fields that cannot or should not store lookup tables in RAM. Generally, "jit-calculate" mode will
         be slower than "jit-lookup". The "auto" mode will determine whether to use "jit-lookup" or "jit-calculate" based on the field's
-        size. In "auto" mode, field's with `order <= 2**16` will use the "jit-lookup" mode.
+        size. In "auto" mode, field's with `order <= 2**20` will use the "jit-lookup" mode.
     target : str, optional
         The `target` keyword argument from :func:`numba.vectorize`, either `"cpu"`, `"parallel"`, or `"cuda"`.
 

--- a/galois/field/factory.py
+++ b/galois/field/factory.py
@@ -8,7 +8,7 @@ __all__ = ["GF", "Field"]
 
 
 @set_module("galois")
-def GF(order, irreducible_poly=None, primitive_element=None, verify_irreducible=True, verify_primitive=True, mode="auto", target="cpu"):
+def GF(order, irreducible_poly=None, primitive_element=None, verify=True, mode="auto", target="cpu"):
     """
     Factory function to construct a Galois field array class of type :math:`\\mathrm{GF}(p^m)`.
 
@@ -30,13 +30,10 @@ def GF(order, irreducible_poly=None, primitive_element=None, verify_irreducible=
         and is a primitive root modulo :math:`p`. For extension fields :math:`\\mathrm{GF}(p^m)`, the primitive element is a polynomial
         of degree less than :math:`m` over :math:`\\mathrm{GF}(p)` or its integer representation. The default is `None` which uses
         :obj:`galois.primitive_root(p)` for prime fields and :obj:`galois.primitive_element(irreducible_poly)` for extension fields.
-    verify_irreducible : bool, optional
-        Indicates whether to verify that the specified irreducible polynomial is in fact irreducible. The default is
-        `True`. For large irreducible polynomials that are already known to be irreducible (and may take a long time to verify),
-        this argument can be set to `False`.
-    verify_primitive : bool, optional
-        Indicates whether to verify that the specified primitive element is in fact a generator of the multiplicative group.
-        The default is `True`.
+    verify : bool, optional
+        Indicates whether to verify that the specified irreducible polynomial is in fact irreducible and that the specified primitive element
+        is in fact a generator of the multiplicative group. The default is `True`. For large fields, irreducible polynomials that are already
+        known to be irreducible (and may take a long time to verify), this argument can be set to `False`.
     mode : str, optional
         The type of field computation, either `"auto"`, `"jit-lookup"`, or `"jit-calculate"`. The default is `"auto"`.
         The "jit-lookup" mode will use Zech log, log, and anti-log lookup tables for efficient calculation. The "jit-calculate"
@@ -96,14 +93,14 @@ def GF(order, irreducible_poly=None, primitive_element=None, verify_irreducible=
     if m == 1:
         if not irreducible_poly is None:
             raise ValueError(f"Argument `irreducible_poly` can only be specified for prime fields, not the extension field GF({p}^{m}).")
-        return GF_prime(p, primitive_element=primitive_element, verify_primitive=verify_primitive, target=target, mode=mode)
+        return GF_prime(p, primitive_element=primitive_element, verify=verify, target=target, mode=mode)
     else:
-        return GF_extension(p, m, primitive_element=primitive_element, irreducible_poly=irreducible_poly, verify_primitive=verify_primitive, verify_irreducible=verify_irreducible, target=target, mode=mode)
+        return GF_extension(p, m, irreducible_poly=irreducible_poly, primitive_element=primitive_element, verify=verify, target=target, mode=mode)
 
 
 @set_module("galois")
-def Field(order, irreducible_poly=None, primitive_element=None, verify_irreducible=True, verify_primitive=True, mode="auto", target="cpu"):
+def Field(order, irreducible_poly=None, primitive_element=None, verify=True, mode="auto", target="cpu"):
     """
     Alias of :func:`galois.GF`.
     """
-    return GF(order, irreducible_poly=irreducible_poly, primitive_element=primitive_element, verify_irreducible=verify_irreducible, verify_primitive=verify_primitive, mode=mode, target=target)
+    return GF(order, irreducible_poly=irreducible_poly, primitive_element=primitive_element, verify=verify, mode=mode, target=target)

--- a/galois/field/factory_extension.py
+++ b/galois/field/factory_extension.py
@@ -1,5 +1,7 @@
 import types
 
+import numpy as np
+
 from ..array import FieldArrayBase
 from ..prime import is_prime
 
@@ -47,8 +49,10 @@ def GF_extension(characteristic, degree, irreducible_poly=None, primitive_elemen
         verify_poly = False  # We don't need to verify Conway polynomials are irreducible
     elif isinstance(irreducible_poly, int):
         irreducible_poly = Poly.Integer(irreducible_poly, field=prime_subfield)
+    elif isinstance(irreducible_poly, (tuple, list, np.ndarray)):
+        irreducible_poly = Poly(irreducible_poly, field=prime_subfield)
     elif not isinstance(irreducible_poly, Poly):
-        raise TypeError(f"Argument `irreducible_poly` must be an integer or galois.Poly, not {type(irreducible_poly)}.")
+        raise TypeError(f"Argument `irreducible_poly` must be an int, tuple, list, np.ndarray, or galois.Poly, not {type(irreducible_poly)}.")
 
     # Get default primitive element
     if primitive_element is None:
@@ -56,8 +60,10 @@ def GF_extension(characteristic, degree, irreducible_poly=None, primitive_elemen
         verify_element = False
     elif isinstance(primitive_element, int):
         primitive_element = Poly.Integer(primitive_element, field=prime_subfield)
+    elif isinstance(primitive_element, (tuple, list, np.ndarray)):
+        primitive_element = Poly(primitive_element, field=prime_subfield)
     elif not isinstance(primitive_element, Poly):
-        raise TypeError(f"Argument `primitive_element` must be an integer or galois.Poly, not {type(primitive_element)}.")
+        raise TypeError(f"Argument `primitive_element` must be an int, tuple, list, np.ndarray, or galois.Poly, not {type(primitive_element)}.")
 
     # Check polynomial fields and degrees
     if not irreducible_poly.field.order == characteristic:

--- a/galois/field/factory_extension.py
+++ b/galois/field/factory_extension.py
@@ -15,7 +15,7 @@ from .poly_functions import primitive_element as _primitive_element  # To avoid 
 # pylint: disable=too-many-branches,too-many-statements,protected-access
 
 
-def GF_extension(characteristic, degree, irreducible_poly=None, primitive_element=None, verify_irreducible=True, verify_primitive=True, mode="auto", target="cpu"):
+def GF_extension(characteristic, degree, irreducible_poly=None, primitive_element=None, verify=True, mode="auto", target="cpu"):
     """
     Class factory for extension fields GF(p^m).
     """
@@ -30,19 +30,21 @@ def GF_extension(characteristic, degree, irreducible_poly=None, primitive_elemen
     order = characteristic**degree
     prime_subfield = GF_prime(characteristic)
     is_primitive_poly = None
+    verify_poly = verify
+    verify_element = verify
 
     if irreducible_poly is None and primitive_element is None:
         irreducible_poly = conway_poly(characteristic, degree)
         is_primitive_poly = True
         primitive_element = Poly.Identity(prime_subfield)
-        verify_irreducible = False  # We don't need to verify Conway polynomials are irreducible
-        verify_primitive = False  # We know `g(x) = x` is a primitive element of the Conway polynomial because Conway polynomials are primitive polynomials
+        verify_poly = False  # We don't need to verify Conway polynomials are irreducible
+        verify_element = False  # We know `g(x) = x` is a primitive element of the Conway polynomial because Conway polynomials are primitive polynomials
 
     # Get default irreducible polynomial
     if irreducible_poly is None:
         irreducible_poly = conway_poly(characteristic, degree)
         is_primitive_poly = True
-        verify_irreducible = False  # We don't need to verify Conway polynomials are irreducible
+        verify_poly = False  # We don't need to verify Conway polynomials are irreducible
     elif isinstance(irreducible_poly, int):
         irreducible_poly = Poly.Integer(irreducible_poly, field=prime_subfield)
     elif not isinstance(irreducible_poly, Poly):
@@ -51,7 +53,7 @@ def GF_extension(characteristic, degree, irreducible_poly=None, primitive_elemen
     # Get default primitive element
     if primitive_element is None:
         primitive_element = _primitive_element(irreducible_poly)
-        verify_primitive = False
+        verify_element = False
     elif isinstance(primitive_element, int):
         primitive_element = Poly.Integer(primitive_element, field=prime_subfield)
     elif not isinstance(primitive_element, Poly):
@@ -76,9 +78,9 @@ def GF_extension(characteristic, degree, irreducible_poly=None, primitive_elemen
 
     name = f"GF{characteristic}_{degree}" if degree > 1 else f"GF{characteristic}"
 
-    if verify_irreducible and not is_irreducible(irreducible_poly):
+    if verify_poly and not is_irreducible(irreducible_poly):
         raise ValueError(f"Argument `irreducible_poly` must be irreducible, {irreducible_poly} is not.")
-    if verify_primitive and not is_primitive_element(primitive_element, irreducible_poly):
+    if verify_element and not is_primitive_element(primitive_element, irreducible_poly):
         raise ValueError(f"Argument `primitive_element` must be a multiplicative generator of GF({characteristic}^{degree}), {primitive_element} is not.")
 
     if characteristic == 2:

--- a/galois/field/factory_prime.py
+++ b/galois/field/factory_prime.py
@@ -11,7 +11,7 @@ from .meta_gfp import GFpMeta
 # pylint: disable=protected-access
 
 
-def GF_prime(characteristic, primitive_element=None, verify_primitive=True, mode="auto", target="cpu"):
+def GF_prime(characteristic, primitive_element=None, verify=True, mode="auto", target="cpu"):
     """
     Class factory for prime fields GF(p).
     """
@@ -36,7 +36,7 @@ def GF_prime(characteristic, primitive_element=None, verify_primitive=True, mode
     if primitive_element is not None:
         if not 0 < primitive_element < order:
             raise ValueError(f"Argument `primitive_element` must be non-zero in the field 0 < x < {order}, not {primitive_element}.")
-        if verify_primitive and not is_primitive_root(primitive_element, characteristic):
+        if verify and not is_primitive_root(primitive_element, characteristic):
             raise ValueError(f"Argument `primitive_element` must be a primitive root modulo {characteristic}, {primitive_element} is not.")
 
     if characteristic == 2:

--- a/galois/field/oakley.py
+++ b/galois/field/oakley.py
@@ -24,7 +24,7 @@ def Oakley1():
     """
     prime = 0xFFFFFFFF_FFFFFFFF_C90FDAA2_2168C234_C4C6628B_80DC1CD1_29024E08_8A67CC74_020BBEA6_3B139B22_514A0879_8E3404DD_EF9519B3_CD3A431B_302B0A6D_F25F1437_4FE1356D_6D51C245_E485B576_625E7EC6_F44C42E9_A63A3620_FFFFFFFF_FFFFFFFF
     generator = 2
-    return GF(prime, primitive_element=generator, verify_primitive=False)
+    return GF(prime, primitive_element=generator, verify=False)
 
 
 @set_module("galois")
@@ -45,7 +45,7 @@ def Oakley2():
     """
     prime = 0xFFFFFFFF_FFFFFFFF_C90FDAA2_2168C234_C4C6628B_80DC1CD1_29024E08_8A67CC74_020BBEA6_3B139B22_514A0879_8E3404DD_EF9519B3_CD3A431B_302B0A6D_F25F1437_4FE1356D_6D51C245_E485B576_625E7EC6_F44C42E9_A637ED6B_0BFF5CB6_F406B7ED_EE386BFB_5A899FA5_AE9F2411_7C4B1FE6_49286651_ECE65381_FFFFFFFF_FFFFFFFF
     generator = 2
-    return GF(prime, primitive_element=generator, verify_irreducible=False, verify_primitive=False)
+    return GF(prime, primitive_element=generator, verify=False)
 
 
 @set_module("galois")
@@ -67,7 +67,7 @@ def Oakley3():
     degree = 155
     irreducible_poly = Poly.Integer(0x0800000000000000000000004000000000000001)
     primitive_element = Poly.Integer(0x7b)
-    return GF(2**degree, irreducible_poly=irreducible_poly, primitive_element=primitive_element, verify_irreducible=False, verify_primitive=False)
+    return GF(2**degree, irreducible_poly=irreducible_poly, primitive_element=primitive_element, verify=False)
 
 
 @set_module("galois")
@@ -89,4 +89,4 @@ def Oakley4():
     degree = 185
     irreducible_poly = Poly.Integer(0x020000000000000000000000000000200000000000000001)
     primitive_element = Poly.Integer(0x18)
-    return GF(2**degree, irreducible_poly=irreducible_poly, primitive_element=primitive_element, verify_irreducible=False, verify_primitive=False)
+    return GF(2**degree, irreducible_poly=irreducible_poly, primitive_element=primitive_element, verify=False)


### PR DESCRIPTION
1. Unify `verify_irreducible` and `verify_primitive` arguments to a single `verify` argument
2. Allow tuples, lists, or ndarrays for `irreducible_poly` and `primitive_element`

Point 2 allows this code
```python
GF = galois.GF(p**2, irreducible_poly=galois.Poly([1,0,1], field=galois.GF(p)), primitive_element=galois.Poly([1,6], field=galois.GF(p)))
```
to be abbreviated to
```python
GF = galois.GF(p**2, irreducible_poly=[1,0,1], primitive_element=[1,6])
```