### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,2 +1,10 @@
-numpy==1.18.4
-numba==0.53
+numpy==1.21.3; python_version=="3.10"
+numpy==1.20.0; python_version=="3.9"
+numpy==1.20.0; python_version=="3.8"
+numpy==1.20.0; python_version=="3.7"
+numpy==1.18.4; python_version=="3.6"
+numba==0.55; python_version=="3.10"
+numba==0.53; python_version=="3.9"
+numba==0.53; python_version=="3.8"
+numba==0.53; python_version=="3.7"
+numba==0.53; python_version=="3.6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ include_package_data = true
 test_suite = tests
 python_requires = >=3.6
 install_requires =
-    numpy >= 1.18.4, < 1.21  # v1.18.4 is needed for the new random, v1.21 has breaking changes to ufuncs
+    numpy >= 1.18.4, < 1.22  # v1.18.4 is needed for the new random, v1.21 has breaking changes to ufuncs
     numba >= 0.53, < 0.56  # v0.53 needed for function signautres of CPUDispatchers
     typing_extensions  # Needed for use of Literal in type hints for Python 3.6 and 3.7
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Mathematics
     Topic :: Security :: Cryptography
     Topic :: Software Development :: Libraries :: Python Modules
@@ -48,7 +49,7 @@ test_suite = tests
 python_requires = >=3.6
 install_requires =
     numpy >= 1.18.4, < 1.21  # v1.18.4 is needed for the new random, v1.21 has breaking changes to ufuncs
-    numba >= 0.53, < 0.55  # v0.53 needed for function signautres of CPUDispatchers
+    numba >= 0.53, < 0.56  # v0.53 needed for function signautres of CPUDispatchers
     typing_extensions  # Needed for use of Literal in type hints for Python 3.6 and 3.7
 
 [options.package_data]


### PR DESCRIPTION
I believe this will require Numba 0.55, which isn't released as of 12/06/21. This PR is awaiting newer versions to re-test.

Update: This PR adds support for Python 3.10 and NumPy 1.21 through Numba 0.55.