### PR TITLE
Change kwarg 'order' to 'ordering'

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -195,7 +195,7 @@ object with the `field` keyword argument.
    p = galois.Poly([172, 22, 0, 0, 225], field=GF256); p
 
    coeffs = GF256([33, 17, 0, 225]); coeffs
-   p = galois.Poly(coeffs, order="asc"); p
+   p = galois.Poly(coeffs, ordering="asc"); p
 
 Polynomials over Galois fields can also display their coefficients as polynomials over their prime subfields.
 This can be quite confusing to read, so be warned!

--- a/galois/_polys/_poly.py
+++ b/galois/_polys/_poly.py
@@ -36,7 +36,7 @@ class Poly:
           in a Galois field, they are assumed to be from :math:`\mathrm{GF}(2)` and are converted using `galois.GF2(coeffs)`.
         * :obj:`galois.FieldClass`: The coefficients are explicitly converted to this Galois field `field(coeffs)`.
 
-    order : str, optional
+    ordering : str, optional
         The interpretation of the coefficient degrees.
 
         * `"desc"` (default): The first element of `coeffs` is the highest degree coefficient, i.e. :math:`\{a_d, a_{d-1}, \dots, a_1, a_0\}`.
@@ -92,20 +92,20 @@ class Poly:
     # Increase my array priority so numpy will call my __radd__ instead of its own __add__
     __array_priority__ = 100
 
-    def __new__(cls, coeffs, field=None, order="desc"):
+    def __new__(cls, coeffs, field=None, ordering="desc"):
         if not isinstance(coeffs, (list, tuple, np.ndarray, FieldArray)):
             raise TypeError(f"Argument `coeffs` must array-like, not {type(coeffs)}.")
         if not isinstance(field, (type(None), FieldClass)):
             raise TypeError(f"Argument `field` must be a Galois field array class, not {field}.")
         if isinstance(coeffs, (FieldArray, np.ndarray)) and not coeffs.ndim <= 1:
             raise ValueError(f"Argument `coeffs` can have dimension at most 1, not {coeffs.ndim}.")
-        if not order in ["desc", "asc"]:
-            raise ValueError(f"Argument `order` must be either 'desc' or 'asc', not {order!r}.")
+        if ordering not in ["desc", "asc"]:
+            raise ValueError(f"Argument `ordering` must be either 'desc' or 'asc', not {ordering!r}.")
 
         if isinstance(coeffs, (FieldArray, np.ndarray)):
             coeffs = np.atleast_1d(coeffs)
 
-        if order == "asc":
+        if ordering == "asc":
             coeffs = coeffs[::-1]  # Ensure it's in descending-degree order
 
         coeffs, field = cls._convert_coeffs(coeffs, field)

--- a/tests/codes/test_bch.py
+++ b/tests/codes/test_bch.py
@@ -188,22 +188,22 @@ def test_bch_generator_poly_diff_primitive_poly():
     Test with primitive polynomial others than the default. Generated in Octave with `bchpoly()`.
     """
     p = galois.Poly.Degrees([3, 2, 0])  # galois.primitive_poly(2, 3, method="max")
-    assert galois.BCH(7, 4, primitive_poly=p).generator_poly == galois.Poly([1,0,1,1], order="asc")
+    assert galois.BCH(7, 4, primitive_poly=p).generator_poly == galois.Poly([1,0,1,1], ordering="asc")
 
     p = galois.Poly.Degrees([4, 3, 0])  # galois.primitive_poly(2, 4, method="max")
-    assert galois.BCH(15, 11, primitive_poly=p).generator_poly == galois.Poly([1,0,0,1,1], order="asc")
-    assert galois.BCH(15, 7, primitive_poly=p).generator_poly == galois.Poly([1,1,1,0,1,0,0,0,1], order="asc")
-    assert galois.BCH(15, 5, primitive_poly=p).generator_poly == galois.Poly([1,0,1,0,0,1,1,0,1,1,1], order="asc")
+    assert galois.BCH(15, 11, primitive_poly=p).generator_poly == galois.Poly([1,0,0,1,1], ordering="asc")
+    assert galois.BCH(15, 7, primitive_poly=p).generator_poly == galois.Poly([1,1,1,0,1,0,0,0,1], ordering="asc")
+    assert galois.BCH(15, 5, primitive_poly=p).generator_poly == galois.Poly([1,0,1,0,0,1,1,0,1,1,1], ordering="asc")
 
     p = galois.Poly.Degrees([5, 4, 3, 2, 0])  # galois.primitive_poly(2, 5, method="max")
-    assert galois.BCH(31, 26, primitive_poly=p).generator_poly == galois.Poly([1,0,1,1,1,1], order="asc")
-    assert galois.BCH(31, 21, primitive_poly=p).generator_poly == galois.Poly([1,1,0,0,0,0,1,1,0,0,1], order="asc")
-    assert galois.BCH(31, 16, primitive_poly=p).generator_poly == galois.Poly([1,1,0,1,1,1,0,1,0,1,0,1,1,1,0,1], order="asc")
-    assert galois.BCH(31, 11, primitive_poly=p).generator_poly == galois.Poly([1,0,1,0,0,0,1,1,0,1,1,0,0,1,1,1,0,0,0,1,1], order="asc")
-    assert galois.BCH(31, 6, primitive_poly=p).generator_poly == galois.Poly([1,0,0,0,1,1,1,0,1,0,1,0,0,1,0,1,1,1,1,0, 0,1,1,0,1,1], order="asc")
+    assert galois.BCH(31, 26, primitive_poly=p).generator_poly == galois.Poly([1,0,1,1,1,1], ordering="asc")
+    assert galois.BCH(31, 21, primitive_poly=p).generator_poly == galois.Poly([1,1,0,0,0,0,1,1,0,0,1], ordering="asc")
+    assert galois.BCH(31, 16, primitive_poly=p).generator_poly == galois.Poly([1,1,0,1,1,1,0,1,0,1,0,1,1,1,0,1], ordering="asc")
+    assert galois.BCH(31, 11, primitive_poly=p).generator_poly == galois.Poly([1,0,1,0,0,0,1,1,0,1,1,0,0,1,1,1,0,0,0,1,1], ordering="asc")
+    assert galois.BCH(31, 6, primitive_poly=p).generator_poly == galois.Poly([1,0,0,0,1,1,1,0,1,0,1,0,0,1,0,1,1,1,1,0, 0,1,1,0,1,1], ordering="asc")
 
     p = galois.Poly.Degrees([6, 5, 4, 1, 0])  # galois.primitive_poly(2, 6, method="max")
-    assert galois.BCH(63, 57, primitive_poly=p).generator_poly == galois.Poly([1,1,0,0,1,1,1], order="asc")
+    assert galois.BCH(63, 57, primitive_poly=p).generator_poly == galois.Poly([1,1,0,0,1,1,1], ordering="asc")
 
 
 def test_bch_parity_check_matrix():

--- a/tests/polys/test_instantiation.py
+++ b/tests/polys/test_instantiation.py
@@ -60,7 +60,7 @@ def test_exceptions():
     with pytest.raises(ValueError):
         galois.Poly(np.array([[1, 0, 1], [1, 1, 1]]))
     with pytest.raises(ValueError):
-        galois.Poly([1, 0, 1], order="invalid-type")
+        galois.Poly([1, 0, 1], ordering="invalid-type")
 
 
 @pytest.mark.parametrize("type1", [list, tuple, np.array, galois.FieldArray])
@@ -87,9 +87,9 @@ def test_leading_zero_coeffs(type1, config):
 def test_ascending_coeffs(type1, config):
     GF = config["GF"]
     if type1 is not galois.FieldArray:
-        p = galois.Poly(type1(config["coeffs"][::-1]), field=GF, order="asc")
+        p = galois.Poly(type1(config["coeffs"][::-1]), field=GF, ordering="asc")
     else:
-        p = galois.Poly(GF(config["coeffs"][::-1]), order="asc")
+        p = galois.Poly(GF(config["coeffs"][::-1]), ordering="asc")
     check_attributes(p, config)
 
 


### PR DESCRIPTION
This was discussed [here](https://github.com/mhostetter/galois/issues/193#issuecomment-961956835) in #193.

The goal of this change is avoiding confusion between the Galois field order (i.e., the number of elements of the finite field) and the arrangement of the coefficients in `galois.Poly`.