### PR TITLE
Make `FieldArray` construction more efficient

### DIFF
--- a/galois/_fields/_gfp.py
+++ b/galois/_fields/_gfp.py
@@ -25,16 +25,15 @@ class GFpMeta(FieldClass, DirMeta):
 
         cls.compile(kwargs["compile"])
 
-    @property
-    def dtypes(cls):
+    def _determine_dtypes(cls):
         """
         The only valid dtypes are ones that can hold x*x for x in [0, order).
         """
         max_dtype = DTYPES[-1]
-        d = [dtype for dtype in DTYPES if np.iinfo(dtype).max >= cls.order - 1 and np.iinfo(max_dtype).max >= (cls.order - 1)**2]
-        if len(d) == 0:
-            d = [np.object_]
-        return d
+        dtypes = [dtype for dtype in DTYPES if np.iinfo(dtype).max >= cls.order - 1 and np.iinfo(max_dtype).max >= (cls.order - 1)**2]
+        if len(dtypes) == 0:
+            dtypes = [np.object_]
+        return dtypes
 
     def _ufunc(cls, name):
         # Some explicit calculation functions are faster than using lookup tables. See https://github.com/mhostetter/galois/pull/92#issuecomment-835548405.

--- a/galois/_fields/_gfpm.py
+++ b/galois/_fields/_gfpm.py
@@ -39,17 +39,16 @@ class GFpmMeta(FieldClass, DirMeta):
             multiply = cls._func_python("multiply")
             cls._is_primitive_poly = cls._function_python("poly_evaluate")(coeffs, x, add, multiply, cls.characteristic, cls.degree, cls._irreducible_poly_int)[0] == 0
 
-    @property
-    def dtypes(cls):
+    def _determine_dtypes(cls):
         """
         The only valid dtypes are ones that can hold x*x for x in [0, order).
         """
         # TODO: Is this correct?
         max_dtype = DTYPES[-1]
-        d = [dtype for dtype in DTYPES if np.iinfo(dtype).max >= cls.order - 1 and np.iinfo(max_dtype).max >= (cls.order - 1)**2]
-        if len(d) == 0:
-            d = [np.object_]
-        return d
+        dtypes = [dtype for dtype in DTYPES if np.iinfo(dtype).max >= cls.order - 1 and np.iinfo(max_dtype).max >= (cls.order - 1)**2]
+        if len(dtypes) == 0:
+            dtypes = [np.object_]
+        return dtypes
 
     def _set_globals(cls, name):
         super()._set_globals(name)

--- a/galois/_fields/_lookup.py
+++ b/galois/_fields/_lookup.py
@@ -38,8 +38,8 @@ class LookupMeta(CalculateMeta):
 
         order = cls.order
         primitive_element = int(cls.primitive_element)
-        add = lambda a, b: cls._func_python("add")(a, b, cls.characteristic, cls.degree, cls._irreducible_poly_int)
-        multiply = lambda a, b: cls._func_python("multiply")(a, b, cls.characteristic, cls.degree, cls._irreducible_poly_int)
+        add = cls._ufunc_python("add")
+        multiply = cls._ufunc_python("multiply")
 
         cls._EXP = np.zeros(2*order, dtype=np.int64)
         cls._LOG = np.zeros(order, dtype=np.int64)
@@ -101,6 +101,7 @@ class LookupMeta(CalculateMeta):
         key = (name, cls.characteristic, cls.degree, cls._irreducible_poly_int)
 
         if key not in cls._UFUNC_CACHE_LOOKUP:
+            # These variables must be locals for Numba to compile them as literals
             EXP = cls._EXP
             LOG = cls._LOG
             ZECH_LOG = cls._ZECH_LOG


### PR DESCRIPTION
As noted in #192, the construction and verification overhead when `__new__()` is called for new `FieldArray` objects can be prohibitively expensive, such as with row reduction.

There are multiple contributors. This PR attempts to resolve them and document the performance impacts. The reference example is below:

```python
In [1]: import numpy as np

In [2]: import galois

In [3]: import cProfile

In [4]: GF = galois.GF(340282366762482138443322565580356624661)

In [5]: np.random.seed(123456789)

In [6]: X = GF.Random((20, 30))

In [7]: %timeit X.row_reduce()
747 ms ± 4.27 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [8]: cProfile.run("X.row_reduce()", sort="tottime")
         2006758 function calls (1967138 primitive calls) in 1.124 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    39760    0.186    0.000    0.648    0.000 _array.py:247(_check_array_values)
   185500    0.118    0.000    0.118    0.000 getlimits.py:514(__init__)
    26500    0.113    0.000    0.274    0.000 _gfp.py:34(<listcomp>)
    79520    0.105    0.000    0.105    0.000 {method 'reduce' of 'numpy.ufunc' objects}
    79560    0.078    0.000    0.400    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
    79520    0.076    0.000    0.281    0.000 fromnumeric.py:70(_wrapreduction)
    79280    0.051    0.000    0.173    0.000 {method 'any' of 'numpy.generic' objects}
    79520    0.041    0.000    0.322    0.000 fromnumeric.py:2256(any)
    79520    0.032    0.000    0.440    0.000 <__array_function__ internals>:2(any)
   185500    0.029    0.000    0.029    0.000 getlimits.py:538(max)
    39640    0.027    0.000    0.027    0.000 {built-in method numpy.array}
       60    0.022    0.000    1.089    0.018 _array.py:227(_check_array_types_dtype_object)
    13380    0.021    0.000    0.831    0.000 _array.py:1093(__getitem__)
    79520    0.019    0.000    0.019    0.000 fromnumeric.py:71(<dictcomp>)
    26500    0.018    0.000    0.294    0.000 _gfp.py:28(dtypes)
    79280    0.018    0.000    0.122    0.000 _methods.py:53(_any)
   225260    0.017    0.000    0.017    0.000 _properties.py:111(order)
 26480/80    0.017    0.000    1.092    0.014 _array.py:177(_check_array_like_object)
   133861    0.015    0.000    0.015    0.000 {built-in method builtins.isinstance}
    13441    0.014    0.000    0.374    0.000 _array.py:1082(__array_finalize__)
 13260/60    0.014    0.000    1.092    0.018 _array.py:1101(__setitem__)
    13220    0.013    0.000    0.796    0.000 _array.py:170(_array)
    13220    0.010    0.000    0.160    0.000 _array.py:157(_get_dtype)
    23400    0.009    0.000    0.022    0.000 _calculate.py:118(<lambda>)
    13560    0.008    0.000    0.382    0.000 {method 'view' of 'numpy.ndarray' objects}
    79520    0.008    0.000    0.008    0.000 fromnumeric.py:2251(_any_dispatcher)
    79440    0.008    0.000    0.008    0.000 {built-in method builtins.getattr}
    13220    0.006    0.000    0.803    0.000 _array.py:115(__new__)
      410    0.006    0.000    0.006    0.000 _gfp.py:91(_reciprocal_calculate)
    79520    0.005    0.000    0.005    0.000 {method 'items' of 'dict' objects}
    13380    0.004    0.000    0.006    0.000 numeric.py:1865(isscalar)
    27100    0.003    0.000    0.003    0.000 {built-in method builtins.len}
    11400    0.002    0.000    0.002    0.000 _gfp.py:86(_multiply_calculate)
    40/20    0.002    0.000    0.011    0.001 {method 'outer' of 'numpy.ufunc' objects}
    23400    0.001    0.000    0.001    0.000 _properties.py:68(characteristic)
       20    0.001    0.000    0.009    0.000 _ufuncs.py:194(_ufunc_routine_subtract)
    23400    0.001    0.000    0.001    0.000 _properties.py:94(degree)
    13220    0.001    0.000    0.001    0.000 _array.py:120(__init__)
    11400    0.001    0.000    0.001    0.000 _gfp.py:78(_subtract_calculate)
      180    0.001    0.000    0.031    0.000 _array.py:1129(__array_ufunc__)
      120    0.001    0.000    0.001    0.000 {function FieldArray.__array_ufunc__ at 0x7f6354155dc0}
        1    0.000    0.000    1.124    1.124 _linalg.py:131(row_reduce)
      180    0.000    0.000    0.001    0.000 _ufuncs.py:145(_view_inputs_as_ndarray)
       20    0.000    0.000    0.008    0.000 _ufuncs.py:219(_ufunc_routine_divide)
      600    0.000    0.000    0.006    0.000 _gfp.py:116(_divide_calculate)
       60    0.000    0.000    0.000    0.000 {method 'astype' of 'numpy.ndarray' objects}
       40    0.000    0.000    0.000    0.000 _array.py:1106(__array_function__)
      180    0.000    0.000    0.000    0.000 _array.py:1136(<listcomp>)
      180    0.000    0.000    0.000    0.000 _array.py:1131(<listcomp>)
       60    0.000    0.000    0.003    0.000 _ufuncs.py:166(_view_output_as_field)
       60    0.000    0.000    0.000    0.000 _gfp.py:39(_ufunc)
      160    0.000    0.000    0.000    0.000 {built-in method _abc._abc_instancecheck}
      400    0.000    0.000    0.000    0.000 {built-in method builtins.issubclass}
      180    0.000    0.000    0.000    0.000 _array.py:1137(<listcomp>)
       20    0.000    0.000    0.011    0.001 _ufuncs.py:201(_ufunc_routine_multiply)
       40    0.000    0.000    0.000    0.000 {method 'nonzero' of 'numpy.ndarray' objects}
      160    0.000    0.000    0.000    0.000 abc.py:96(__instancecheck__)
       40    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(nonzero)
       40    0.000    0.000    0.000    0.000 {function FieldArray.__array_function__ at 0x7f6354155d30}
        1    0.000    0.000    0.000    0.000 {method 'copy' of 'numpy.ndarray' objects}
       40    0.000    0.000    0.000    0.000 fromnumeric.py:1827(nonzero)
       40    0.000    0.000    0.000    0.000 fromnumeric.py:52(_wrapfunc)
       40    0.000    0.000    0.000    0.000 _ufuncs.py:102(_verify_operands_in_same_field)
       60    0.000    0.000    0.000    0.000 _ufuncs.py:73(_ufunc)
       20    0.000    0.000    0.000    0.000 {method 'tolist' of 'numpy.ndarray' objects}
        1    0.000    0.000    1.124    1.124 {built-in method builtins.exec}
       40    0.000    0.000    0.000    0.000 fromnumeric.py:1823(_nonzero_dispatcher)
       20    0.000    0.000    0.000    0.000 {method 'remove' of 'list' objects}
       40    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    1.124    1.124 <string>:1(<module>)
        1    0.000    0.000    1.124    1.124 _array.py:618(row_reduce)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
```