### PR TITLE
Support `ndarray.dot()`

### DIFF
--- a/galois/_fields/_array.py
+++ b/galois/_fields/_array.py
@@ -9,7 +9,7 @@ from .._overrides import set_module
 from .._poly_conversion import str_to_integer
 
 from ._class import FieldClass
-from ._linalg import row_reduce, lu_decompose, lup_decompose
+from ._linalg import dot, row_reduce, lu_decompose, lup_decompose
 
 __all__ = ["FieldArray"]
 
@@ -1076,11 +1076,6 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
     # Overridden numpy methods
     ###############################################################################
 
-    def astype(self, dtype, **kwargs):  # pylint: disable=arguments-differ
-        if dtype not in type(self).dtypes:
-            raise TypeError(f"{type(self).name} arrays can only be cast as integer dtypes in {type(self).dtypes}, not {dtype}.")
-        return super().astype(dtype, **kwargs)
-
     def __array_finalize__(self, obj):
         """
         A numpy dunder method that is called after "new", "view", or "new from template". It is used here to ensure
@@ -1168,6 +1163,15 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
                 output = output.view(type(self)) if not np.isscalar(output) else type(self)(output, dtype=self.dtype)
 
             return output
+
+    def astype(self, dtype, **kwargs):  # pylint: disable=arguments-differ
+        if dtype not in type(self).dtypes:
+            raise TypeError(f"{type(self).name} arrays can only be cast as integer dtypes in {type(self).dtypes}, not {dtype}.")
+        return super().astype(dtype, **kwargs)
+
+    def dot(self, b, out=None):
+        # `np.dot(a, b)` is also available as `a.dot(b)`. Need to override this here for proper results.
+        return dot(self, b, out=out)
 
     ###############################################################################
     # Display methods

--- a/tests/fields/test_linalg.py
+++ b/tests/fields/test_linalg.py
@@ -15,7 +15,13 @@ def test_dot_scalar(field):
     dtype = random.choice(field.dtypes)
     a = field.Random((3,3), dtype=dtype)
     b = field.Random(dtype=dtype)
+
     c = np.dot(a, b)
+    assert type(c) is field
+    assert c.dtype == dtype
+    assert array_equal(c, a * b)
+
+    c = a.dot(b)
     assert type(c) is field
     assert c.dtype == dtype
     assert array_equal(c, a * b)
@@ -25,7 +31,13 @@ def test_dot_vector_vector(field):
     dtype = random.choice(field.dtypes)
     a = field.Random(3, dtype=dtype)
     b = field.Random(3, dtype=dtype)
+
     c = np.dot(a, b)
+    assert type(c) is field
+    assert c.dtype == dtype
+    assert array_equal(c, np.sum(a * b))
+
+    c = a.dot(b)
     assert type(c) is field
     assert c.dtype == dtype
     assert array_equal(c, np.sum(a * b))
@@ -35,7 +47,13 @@ def test_dot_matrix_matrix(field):
     dtype = random.choice(field.dtypes)
     A = field.Random((3,3), dtype=dtype)
     B = field.Random((3,3), dtype=dtype)
+
     C = np.dot(A, B)
+    assert type(C) is field
+    assert C.dtype == dtype
+    assert array_equal(C, A @ B)
+
+    C = A.dot(B)
     assert type(C) is field
     assert C.dtype == dtype
     assert array_equal(C, A @ B)
@@ -45,7 +63,13 @@ def test_dot_tensor_vector(field):
     dtype = random.choice(field.dtypes)
     A = field.Random((3,4,5), dtype=dtype)
     b = field.Random(5, dtype=dtype)
+
     C = np.dot(A, b)
+    assert type(C) is field
+    assert C.dtype == dtype
+    assert array_equal(C, np.sum(A * b, axis=-1))
+
+    C = A.dot(b)
     assert type(C) is field
     assert C.dtype == dtype
     assert array_equal(C, np.sum(A * b, axis=-1))


### PR DESCRIPTION
As pointed out in #202, currently `ndarray.dot()` isn't overridden / supported. This PR adds that.

Now `a.dot(b)` works the same as `np.dot(a, b)`.

```python
In [1]: import galois

In [2]: import numpy as np

In [3]: a = galois.GF2.Random(4); a
Out[3]: GF([1, 1, 0, 0], order=2)

In [4]: b = galois.GF2.Random((4,4)); b
Out[4]: 
GF([[1, 0, 1, 1],
    [1, 0, 1, 0],
    [0, 1, 1, 1],
    [0, 1, 1, 0]], order=2)

In [5]: np.dot(a, b)
Out[5]: GF([0, 0, 0, 1], order=2)

In [6]: a @ b
Out[6]: GF([0, 0, 0, 1], order=2)

In [7]: a.dot(b)
Out[7]: GF([0, 0, 0, 1], order=2)
```