### PR TITLE
Fix `np.arange()` exponentiation overflows

### DIFF
--- a/galois/_codes/_bch.py
+++ b/galois/_codes/_bch.py
@@ -89,7 +89,7 @@ def bch_valid_codes(n, t_min=1):
     while True:
         c = 1
         roots = alpha**(c + np.arange(0, 2*t))
-        powers = GF.characteristic**np.arange(0, GF.degree)
+        powers = GF.characteristic**np.arange(0, GF.degree, dtype=GF.dtypes[-1])
         conjugates = np.unique(np.power.outer(roots, powers))
         g_degree = len(conjugates)
         k = n - g_degree
@@ -201,7 +201,7 @@ class BCH:
             # minimal polynomial and then doing an LCM, we will compute all the unique conjugates of all the roots
             # and then compute (x - c1)*(x - c2)*...*(x - cn), which is equivalent.
             roots = alpha**(c + np.arange(0, 2*t))
-            powers = GF.characteristic**np.arange(0, GF.degree)
+            powers = GF.characteristic**np.arange(0, GF.degree, dtype=GF.dtypes[-1])
             conjugates = np.unique(np.power.outer(roots, powers))
             g_degree = len(conjugates)
 

--- a/galois/_codes/_cyclic.py
+++ b/galois/_codes/_cyclic.py
@@ -109,6 +109,7 @@ def roots_to_parity_check_matrix(n, roots):
     if not isinstance(roots, FieldArray):
         raise TypeError(f"Argument `roots` must be a galois.FieldArray, not {type(roots)}.")
 
-    H = np.power.outer(roots, np.arange(n - 1, -1, -1))
+    GF = type(roots)
+    H = np.power.outer(roots, np.arange(n - 1, -1, -1, dtype=GF.dtypes[-1]))
 
     return H

--- a/galois/_fields/_array.py
+++ b/galois/_fields/_array.py
@@ -765,7 +765,7 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
         subfield = field.prime_subfield
         p = field.characteristic
         m = field.degree
-        conjugates = np.power.outer(self, p**np.arange(0, m, dtype=self.dtype))
+        conjugates = np.power.outer(self, p**np.arange(0, m, dtype=field.dtypes[-1]))
         trace = np.add.reduce(conjugates, axis=-1)
         return subfield(trace)
 

--- a/galois/_fields/_class.py
+++ b/galois/_fields/_class.py
@@ -313,7 +313,7 @@ class FieldClass(FunctionMeta, UfuncMeta, PropertiesMeta):
 
         if cls.display_mode == "power":
             # Order elements by powers of the primitive element
-            x_default = np.concatenate((np.atleast_1d(cls(0)), cls.primitive_element**np.arange(0, cls.order - 1)))
+            x_default = np.concatenate((np.atleast_1d(cls(0)), cls.primitive_element**np.arange(0, cls.order - 1, dtype=cls.dtypes[-1])))
         else:
             x_default = cls.Elements()
         y_default = x_default if operation != "/" else x_default[1:]

--- a/galois/_polys/_functions.py
+++ b/galois/_polys/_functions.py
@@ -113,7 +113,7 @@ def minimal_poly(element):
     if field.is_prime_field:
         return x - element
     else:
-        conjugates = np.unique(element**(field.characteristic**np.arange(0, field.degree)))
+        conjugates = np.unique(element**(field.characteristic**np.arange(0, field.degree, dtype=field.dtypes[-1])))
         poly = Poly.Roots(conjugates, field=field)
         poly = Poly(poly.coeffs, field=field.prime_subfield)
         return poly

--- a/tests/polys/test_minimal_polys.py
+++ b/tests/polys/test_minimal_polys.py
@@ -380,3 +380,11 @@ def test_minimal_poly(characteristic, degree):
         e = GFpm(item[0])
         poly = galois.Poly(item[1], field=GFp)
         assert galois.minimal_poly(e) == poly
+
+
+def test_minimal_poly_large_field():
+    # Test vectors generated with SageMath
+    GF = galois.GF(2**100)
+    galois.minimal_poly(GF(2)) == galois.Poly.String("x^100 + x^57 + x^56 + x^55 + x^52 + x^48 + x^47 + x^46 + x^45 + x^44 + x^43 + x^41 + x^37 + x^36 + x^35 + x^34 + x^31 + x^30 + x^27 + x^25 + x^24 + x^22 + x^20 + x^19 + x^16 + x^15 + x^11 + x^9 + x^8 + x^6 + x^5 + x^3 + 1")
+    galois.minimal_poly(GF(3)) == galois.Poly.String("x^100 + x^96 + x^68 + x^64 + x^57 + x^55 + x^54 + x^53 + x^51 + x^50 + x^48 + x^47 + x^42 + x^41 + x^38 + x^36 + x^31 + x^29 + x^26 + x^24 + x^15 + x^14 + x^12 + x^9 + x^8 + x^5 + x^2 + x + 1")
+    galois.minimal_poly(GF(6)) == galois.Poly.String("x^100 + x^78 + x^76 + x^74 + x^73 + x^71 + x^67 + x^66 + x^65 + x^62 + x^60 + x^55 + x^52 + x^51 + x^50 + x^48 + x^47 + x^45 + x^42 + x^41 + x^35 + x^34 + x^33 + x^31 + x^30 + x^29 + x^28 + x^27 + x^26 + x^23 + x^22 + x^21 + x^20 + x^19 + x^16 + x^14 + x^13 + x^12 + x^10 + x^9 + x^8 + x^6 + x^3 + x + 1")


### PR DESCRIPTION
Fixes #205.

For `x**np.arange(a, b)`, the default dtype is `int`, which on most platforms is `np.int64`. If `x**b` is larger than `2**63`, the calculation will overflow and result in 0 or a negative value. This can be resolved by specifying `x**np.arange(a, b, dtype=GF.dtypes[-1])`, which uses the largest dtype for the given field.