### PR TITLE
Add additive and multiplicative order methods to `FieldArray`

### DIFF
--- a/galois/_codes/_bch.py
+++ b/galois/_codes/_bch.py
@@ -417,7 +417,7 @@ class BCH:
     def decode(self, codeword: Union[np.ndarray, GF2], errors: Literal[False] = False) -> Union[np.ndarray, GF2]:
         ...
     @overload
-    def decode(self, codeword: Union[np.ndarray, GF2], errors: Literal[True] = True) -> Tuple[Union[np.ndarray, GF2], Union[int, np.ndarray]]:
+    def decode(self, codeword: Union[np.ndarray, GF2], errors: Literal[True] = True) -> Tuple[Union[np.ndarray, GF2], Union[np.integer, np.ndarray]]:
         ...
     def decode(self, codeword, errors=False):
         r"""
@@ -436,7 +436,7 @@ class BCH:
         -------
         numpy.ndarray, galois.GF2
             The decoded message as either a :math:`k`-length vector or :math:`(N, k)` matrix.
-        int, np.ndarray
+        numpy.integer, numpy.ndarray
             Optional return argument of the number of corrected bit errors as either a scalar or :math:`n`-length vector.
             Valid number of corrections are in :math:`[0, t]`. If a codeword has too many errors and cannot be corrected,
             -1 will be returned.

--- a/galois/_codes/_reed_solomon.py
+++ b/galois/_codes/_reed_solomon.py
@@ -321,7 +321,7 @@ class ReedSolomon:
     def decode(self, codeword: Union[np.ndarray, FieldArray], errors: Literal[False] = False) -> Union[np.ndarray, FieldArray]:
         ...
     @overload
-    def decode(self, codeword: Union[np.ndarray, FieldArray], errors: Literal[True] = True) -> Tuple[Union[np.ndarray, FieldArray], Union[int, np.ndarray]]:
+    def decode(self, codeword: Union[np.ndarray, FieldArray], errors: Literal[True] = True) -> Tuple[Union[np.ndarray, FieldArray], Union[np.integer, np.ndarray]]:
         ...
     def decode(self, codeword, errors=False):
         r"""
@@ -340,7 +340,7 @@ class ReedSolomon:
         -------
         numpy.ndarray, galois.FieldArray
             The decoded message as either a :math:`k`-length vector or :math:`(N, k)` matrix.
-        int, np.ndarray
+        numpy.integer, numpy.ndarray
             Optional return argument of the number of corrected symbol errors as either a scalar or :math:`n`-length vector.
             Valid number of corrections are in :math:`[0, t]`. If a codeword has too many errors and cannot be corrected,
             -1 will be returned.

--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -1573,6 +1573,44 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
     # Instance methods
     ###############################################################################
 
+    def additive_order(self) -> Union[np.integer, np.ndarray]:
+        r"""
+        Computes the additive order of each element in :math:`x`.
+
+        Returns
+        -------
+        numpy.integer, numpy.ndarray
+            An integer array of the additive order of each element in :math:`x`. The return value is a single integer if the
+            input array :math:`x` is a scalar.
+
+        Notes
+        -----
+        The additive order :math:`a` of :math:`x` in :math:`\mathrm{GF}(p^m)` is the smallest integer :math:`a`
+        such that :math:`x a = 0`. With the exception of :math:`0`, the additive order of every element is
+        the finite field's characteristic.
+
+        Examples
+        --------
+        Below is the additive order of each element of :math:`\mathrm{GF}(2^4)`.
+
+        .. ipython:: python
+
+            GF = galois.GF(2**4)
+            x = GF.Elements(); x
+            order = x.additive_order(); order
+            x*order
+        """
+        x = self
+        field = type(self)
+
+        if x.ndim == 0:
+            order = np.int64(1) if x == 0 else np.int64(field.characteristic)
+        else:
+            order = field.characteristic * np.ones(x.shape, dtype=np.int64)
+            order[np.where(x == 0)] = 1
+
+        return order
+
     def multiplicative_order(self) -> Union[np.integer, np.ndarray]:
         r"""
         Computes the multiplicative order :math:`\textrm{ord}(x)` of each element in :math:`x`.

--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -12,6 +12,7 @@ from typing_extensions import Literal
 import numba
 import numpy as np
 
+from .._factor import divisors
 from .._overrides import set_module
 from .._poly_conversion import integer_to_poly, poly_to_integer, str_to_integer, poly_to_str, sparse_poly_to_integer, sparse_poly_to_str, str_to_sparse_poly
 
@@ -1571,6 +1572,57 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
     ###############################################################################
     # Instance methods
     ###############################################################################
+
+    def multiplicative_order(self) -> Union[np.integer, np.ndarray]:
+        r"""
+        Computes the multiplicative order :math:`\textrm{ord}(x)` of each element in :math:`x`.
+
+        Returns
+        -------
+        numpy.integer, numpy.ndarray
+            An integer array of the multiplicative order of each element in :math:`x`. The return value is a single integer if the
+            input array :math:`x` is a scalar.
+
+        Notes
+        -----
+        The multiplicative order :math:`\textrm{ord}(x) = a` of :math:`x` in :math:`\mathrm{GF}(p^m)` is the smallest power :math:`a`
+        such that :math:`x^a = 1`. If :math:`a = p^m - 1`, :math:`a` is said to be a generator of the multiplicative group
+        :math:`\mathrm{GF}(p^m)^\times`.
+
+        The multiplicative order of :math:`0` is not defined and will raise an :obj:`ArithmeticError`.
+
+        :func:`FieldArray.multiplicative_order` should not be confused with :obj:`FieldClass.order`. The former is a method on a
+        Galois field array that returns the multiplicative order of elements. The latter is a property of the field, namely
+        the finite field's order or size.
+
+        Examples
+        --------
+        Below is the multiplicative order of each non-zero element of :math:`\mathrm{GF}(2^4)`. The elements with
+        :math:`\textrm{ord}(x) = 15` are multiplicative generators of :math:`\mathrm{GF}(2^4)^\times`
+
+        .. ipython:: python
+
+            GF = galois.GF(2**4)
+            # The multiplicative order of 0 is not defined
+            x = GF.Range(1, GF.order); x
+            order = x.multiplicative_order(); order
+            # Elements with order of 15 are the primitive elements (generators) of the field
+            GF.primitive_elements
+            x**order
+        """
+        if not np.count_nonzero(self) == self.size:
+            raise ArithmeticError("The multiplicative order of 0 is not defined.")
+
+        x = self
+        field = type(self)
+
+        # TODO: Implement a better algorithm
+        d = np.array(divisors(field.order - 1))  # Divisors d such that d | p^m - 1
+        y = np.power.outer(x, d)  # x^d -- the first divisor d for which x^d == 1 is the order of x
+        idxs = np.argmin(np.abs(y.view(np.ndarray) - 1), axis=-1)  # First index of divisors, which is the order of x
+        order = d[idxs]  # The order of each element of x
+
+        return order
 
     def vector(
         self,

--- a/tests/fields/test_additive_order.py
+++ b/tests/fields/test_additive_order.py
@@ -1,0 +1,143 @@
+"""
+A pytest module to test the additive order of elements of finite fields.
+
+Sage:
+    F = GF(2**3)
+    y = []
+    for x in range(0, F.order()):
+        x = F.fetch_int(x)
+        y.append(x.additive_order())
+    print(y)
+"""
+import pytest
+import numpy as np
+
+import galois
+
+
+# def test_exceptions():
+#     # None currently
+
+
+def test_shapes():
+    # NOTE: 1-D arrays are tested in other tests
+    GF = galois.GF(3**3)
+    x = GF.Elements()
+    y_truth = [1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]
+
+    # Scalar
+    y0 = x[0].additive_order()
+    assert np.array_equal(y0, y_truth[0])
+    assert isinstance(y0, np.integer)
+
+    # N-D
+    y = x.reshape((3,3,3)).additive_order()
+    assert np.array_equal(y, np.array(y_truth).reshape(3,3,3))
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_field():
+    GF = galois.GF(2)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 2]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_field_1():
+    GF = galois.GF(7)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 7, 7, 7, 7, 7, 7]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_field_2():
+    GF = galois.GF(31)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_field_3():
+    GF = galois.GF(79)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_extension_field_1():
+    GF = galois.GF(2**3)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 2, 2, 2, 2, 2, 2, 2]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_extension_field_2():
+    GF = galois.GF(2**4)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_extension_field_3():
+    # Use an irreducible, but not primitive, polynomial
+    GF = galois.GF(2**4, irreducible_poly="x^4 + x^3 + x^2 + x + 1")
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_extension_field_4():
+    GF = galois.GF(2**5)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_extension_field_1():
+    GF = galois.GF(3**2)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 3, 3, 3, 3, 3, 3, 3, 3]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_extension_field_2():
+    GF = galois.GF(3**3)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_extension_field_3():
+    GF = galois.GF(5**2)
+    x = GF.Elements()
+    y = x.additive_order()
+    y_truth = [1, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_property_1():
+    GF = galois.GF(2**8)
+    x = GF.Random(10)
+    order = x.additive_order()
+    assert np.all(x*order == 0)

--- a/tests/fields/test_field_norm.py
+++ b/tests/fields/test_field_norm.py
@@ -36,7 +36,7 @@ def test_shapes():
     # N-D
     y = x.reshape((3,3,3)).field_norm()
     assert np.array_equal(y, np.array(y_truth).reshape(3,3,3))
-    assert isinstance(y0, GF.prime_subfield)
+    assert isinstance(y, GF.prime_subfield)
 
 
 def test_binary_extension_1():

--- a/tests/fields/test_field_trace.py
+++ b/tests/fields/test_field_trace.py
@@ -36,7 +36,7 @@ def test_shapes():
     # N-D
     y = x.reshape((3,3,3)).field_trace()
     assert np.array_equal(y, np.array(y_truth).reshape(3,3,3))
-    assert isinstance(y0, GF.prime_subfield)
+    assert isinstance(y, GF.prime_subfield)
 
 
 def test_binary_extension_1():

--- a/tests/fields/test_multiplicative_order.py
+++ b/tests/fields/test_multiplicative_order.py
@@ -1,0 +1,147 @@
+"""
+A pytest module to test the multiplicative order of elements of finite fields.
+
+Sage:
+    F = GF(2**3)
+    y = []
+    for x in range(1, F.order()):
+        x = F.fetch_int(x)
+        y.append(x.multiplicative_order())
+    print(y)
+"""
+import pytest
+import numpy as np
+
+import galois
+
+
+def test_exceptions():
+    GF = galois.GF(3)
+    with pytest.raises(ArithmeticError):
+        GF(0).multiplicative_order()
+    with pytest.raises(ArithmeticError):
+        GF.Elements().multiplicative_order()
+
+
+def test_shapes():
+    # NOTE: 1-D arrays are tested in other tests
+    GF = galois.GF(3**3)
+    x = GF.Range(1, GF.order)
+    y_truth = [1, 2, 26, 26, 26, 13, 13, 13, 13, 26, 13, 13, 13, 26, 13, 13, 26, 26, 26, 13, 26, 13, 26, 26, 13, 26]
+
+    # Scalar
+    y0 = x[0].multiplicative_order()
+    assert np.array_equal(y0, y_truth[0])
+    assert isinstance(y0, np.integer)
+
+    # N-D
+    y = x.reshape((2,13)).multiplicative_order()
+    assert np.array_equal(y, np.array(y_truth).reshape(2,13))
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_field():
+    GF = galois.GF(2)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1,]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_field_1():
+    GF = galois.GF(7)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 3, 6, 3, 6, 2]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_field_2():
+    GF = galois.GF(31)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 5, 30, 5, 3, 6, 15, 5, 15, 15, 30, 30, 30, 15, 10, 5, 30, 15, 15, 15, 30, 30, 10, 30, 3, 6, 10, 15, 10, 2]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_field_3():
+    GF = galois.GF(79)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 39, 78, 39, 39, 78, 78, 13, 39, 13, 39, 26, 39, 26, 26, 39, 26, 13, 39, 39, 13, 13, 3, 6, 39, 39, 26, 78, 78, 78, 39, 39, 26, 78, 78, 39, 78, 13, 78, 39, 26, 39, 78, 39, 39, 13, 78, 78, 39, 39, 39, 13, 78, 78, 3, 6, 26, 26, 78, 78, 26, 13, 78, 13, 13, 78, 13, 78, 26, 78, 26, 39, 39, 78, 78, 39, 78, 2]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_extension_field_1():
+    GF = galois.GF(2**3)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 7, 7, 7, 7, 7, 7]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_extension_field_2():
+    GF = galois.GF(2**4)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 15, 15, 15, 15, 3, 3, 5, 15, 5, 15, 5, 15, 15, 5]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_extension_field_3():
+    # Use an irreducible, but not primitive, polynomial
+    GF = galois.GF(2**4, irreducible_poly="x^4 + x^3 + x^2 + x + 1")
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 5, 15, 5, 15, 15, 15, 5, 15, 15, 15, 3, 3, 15, 5]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_binary_extension_field_4():
+    GF = galois.GF(2**5)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_extension_field_1():
+    GF = galois.GF(3**2)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 2, 8, 4, 8, 8, 8, 4]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_extension_field_2():
+    GF = galois.GF(3**3)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 2, 26, 26, 26, 13, 13, 13, 13, 26, 13, 13, 13, 26, 13, 13, 26, 26, 26, 13, 26, 13, 26, 26, 13, 26]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_prime_extension_field_3():
+    GF = galois.GF(5**2)
+    x = GF.Range(1, GF.order)
+    y = x.multiplicative_order()
+    y_truth = [1, 4, 4, 2, 24, 12, 8, 12, 24, 24, 3, 6, 24, 8, 24, 8, 24, 3, 6, 24, 24, 12, 8, 12]
+    assert np.array_equal(y, y_truth)
+    assert isinstance(y, np.ndarray)
+
+
+def test_property_1():
+    GF = galois.GF(2**8)
+    x = GF.Random(10, low=1)
+    order = x.multiplicative_order()
+    assert np.all(x**order == 1)


### PR DESCRIPTION
```python
In [1]: import galois

In [2]: GF = galois.GF(2**4)

In [3]: x = GF.Elements()

In [4]: x.additive_order()
Out[4]: array([1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])

In [5]: x * x.additive_order()
Out[5]: GF([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], order=2^4)
```

```python
In [1]: import galois

In [2]: GF = galois.GF(2**4)

In [3]: x = GF.Range(1, GF.order); x
Out[3]: 
GF([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15],
   order=2^4)

In [4]: x.multiplicative_order()
Out[4]: array([ 1, 15, 15, 15, 15,  3,  3,  5, 15,  5, 15,  5, 15, 15,  5])

In [5]: x ** x.multiplicative_order()
Out[5]: GF([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], order=2^4)
```