### PR TITLE
Make `prev_prime()` and `next_prime()` without bound

### DIFF
--- a/galois/_prime.py
+++ b/galois/_prime.py
@@ -186,13 +186,23 @@ def next_prime(n: int) -> int:
 
         galois.next_prime(13)
         galois.next_prime(15)
+        galois.next_prime(6852976918500265458318414454675831645298)
     """
     if not isinstance(n, (int, np.integer)):
         raise TypeError(f"Argument `n` must be an integer, not {type(n)}.")
-    if not n < PRIMES[-1]:
-        raise ValueError(f"Argument `n` is out of range of the prime lookup table. The lookup table only stores primes <= {MAX_N}.")
 
-    return PRIMES[bisect.bisect_right(PRIMES, n)]
+    # Directly use lookup table
+    if n < PRIMES[-1]:
+        return PRIMES[bisect.bisect_right(PRIMES, n)]
+
+    # TODO: Make this faster using wheel factorization
+    n = n + 1 if n % 2 == 0 else n + 2  # The next possible prime (which is odd)
+    while True:
+        n += 2  # Only check odds
+        if is_prime(n):
+            break
+
+    return n
 
 
 @set_module("galois")

--- a/galois/_prime.py
+++ b/galois/_prime.py
@@ -153,16 +153,26 @@ def prev_prime(n: int) -> Optional[int]:
 
         galois.prev_prime(13)
         galois.prev_prime(15)
+        galois.prev_prime(6298891201241929548477199440981228280038)
     """
     if not isinstance(n, (int, np.integer)):
         raise TypeError(f"Argument `n` must be an integer, not {type(n)}.")
-    if not n <= MAX_N:
-        raise ValueError(f"Argument `n` is out of range of the prime lookup table. The lookup table only stores primes <= {MAX_N}.")
 
     if n < 2:
         return None
 
-    return PRIMES[bisect.bisect_right(PRIMES, n) - 1]
+    # Directly use lookup table
+    if n <= MAX_N:
+        return PRIMES[bisect.bisect_right(PRIMES, n) - 1]
+
+    # TODO: Make this faster using wheel factorization
+    n = n - 1 if n % 2 == 0 else n  # The next possible prime (which is odd)
+    while True:
+        n -= 2  # Only check odds
+        if is_prime(n):
+            break
+
+    return n
 
 
 @set_module("galois")

--- a/tests/test_primes.py
+++ b/tests/test_primes.py
@@ -58,16 +58,25 @@ def test_prev_prime():
 def test_next_prime_exceptions():
     with pytest.raises(TypeError):
         galois.next_prime(20.0)
-    with pytest.raises(ValueError):
-        galois.next_prime(galois._prime.MAX_N)
 
 
 def test_next_prime():
+    """
+    Sage:
+        n = randint(1e20, 1e40)
+        p = next_prime(n)
+        print(n, p)
+    """
     assert galois.next_prime(-10) == 2
     assert galois.next_prime(1) == 2
     assert galois.next_prime(2) == 3
     assert galois.next_prime(8) == 11
     assert galois.next_prime(11) == 13
+
+    assert galois.next_prime(6852976918500265458318414454675831645298) == 6852976918500265458318414454675831645343
+    assert galois.next_prime(3572414920255490866338499919876578953336) == 3572414920255490866338499919876578953521
+    assert galois.next_prime(2586430993484535570784866034349245707842) == 2586430993484535570784866034349245708081
+    assert galois.next_prime(5854185879525630749384072249732042426759) == 5854185879525630749384072249732042426801
 
 
 def test_random_prime_exceptions():

--- a/tests/test_primes.py
+++ b/tests/test_primes.py
@@ -43,16 +43,25 @@ def test_kth_prime():
 def test_prev_prime_exceptions():
     with pytest.raises(TypeError):
         galois.prev_prime(20.0)
-    with pytest.raises(ValueError):
-        galois.prev_prime(galois._prime.MAX_N + 1)
 
 
 def test_prev_prime():
+    """
+    Sage:
+        n = randint(1e20, 1e40)
+        p = previous_prime(n)
+        print(n, p)
+    """
     assert galois.prev_prime(-10) is None
     assert galois.prev_prime(1) is None
     assert galois.prev_prime(2) == 2
     assert galois.prev_prime(8) == 7
     assert galois.prev_prime(11) == 11
+
+    assert galois.prev_prime(6298891201241929548477199440981228280038) == 6298891201241929548477199440981228279991
+    assert galois.prev_prime(2245986882959070275565383172237929066361) == 2245986882959070275565383172237929066273
+    assert galois.prev_prime(9259519322042859167754950040306622329138) == 9259519322042859167754950040306622328867
+    assert galois.prev_prime(8385429707258740720790261449080131360283) == 8385429707258740720790261449080131360143
 
 
 def test_next_prime_exceptions():


### PR DESCRIPTION
The functions now work as follows:

```python
In [1]: import galois

In [2]: galois.prev_prime(10_000_000)
Out[2]: 9999991

In [3]: galois.prev_prime(10_000_000 + 1)
Out[3]: 9999991

In [4]: galois.next_prime(10_000_000)
Out[4]: 10000019

In [5]: galois.next_prime(10_000_019)
Out[5]: 10000079
```