### PR TITLE
Add functions to test and return quadratic (non-)residues

### DIFF
--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -1281,7 +1281,7 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
     @classmethod
     def Ones(
         cls,
-        shape: Union[int, Tuple[()], Tuple[int]],
+        shape: Union[int, Sequence[int]],
         dtype: Optional[Union[np.dtype, int, object]] = None
     ) -> "FieldArray":
         """
@@ -1357,7 +1357,7 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
     @classmethod
     def Random(
         cls,
-        shape: Union[int, Tuple[()], Tuple[int]] = (),
+        shape: Union[int, Sequence[int]] = (),
         low: Optional[int] = 0,
         high: Optional[int] = None,
         seed: Optional[Union[int, np.random.Generator]] = None,

--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -1015,7 +1015,7 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
         b = GF256([66, 166, 27, 182, 125], dtype=np.int64); b
         b.dtype
     """
-    # pylint: disable=unsupported-membership-test,not-an-iterable
+    # pylint: disable=unsupported-membership-test,not-an-iterable,too-many-public-methods
 
     def __new__(
         cls,
@@ -1668,6 +1668,58 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
             order = d[idxs]  # The order of each element of x
 
         return order
+
+    def is_quadratic_residue(self) -> Union[np.bool_, np.ndarray]:
+        r"""
+        Determines if the elements of :math:`x` are quadratic residues in the Galois field.
+
+        Returns
+        -------
+        numpy.bool_, numpy.ndarray
+            An boolean array indicating if each element in :math:`x` is a quadratic residue. The return value is a single boolean if the
+            input array :math:`x` is a scalar.
+
+        Notes
+        -----
+        An element :math:`x` in :math:`\mathrm{GF}(p^m)` is a *quadratic residue* if there exists a :math:`y` such that
+        :math:`y^2 = x` in the field.
+
+        In fields with characteristic 2, every element is a quadratic residue. In fields with characteristic greater than 2,
+        exactly half of the nonzero elements are quadratic residues (and they have two unique square roots).
+
+        References
+        ----------
+        * Section 3.5.1 from https://cacr.uwaterloo.ca/hac/about/chap3.pdf.
+
+        Examples
+        --------
+        .. ipython:: python
+
+            GF = galois.GF(11)
+            x = GF.Elements(); x
+            x.is_quadratic_residue()
+
+        .. ipython:: python
+
+            GF = galois.GF(2**4)
+            x = GF.Elements(); x
+            x.is_quadratic_residue()
+
+        .. ipython:: python
+
+            GF = galois.GF(3**3)
+            x = GF.Elements(); x
+            x.is_quadratic_residue()
+        """
+        x = self
+        field = type(self)
+
+        if field.characteristic == 2:
+            # All elements are quadratic residues if the field's characteristic is 2
+            return np.ones(x.shape, dtype=bool) if x.ndim > 0 else np.bool_(True)
+        else:
+            # Compute the Legendre symbol on each element
+            return x ** ((field.order - 1)//2) != field.characteristic - 1
 
     def vector(
         self,

--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -670,6 +670,35 @@ class FieldClass(FunctionMeta, UfuncMeta):
         return np.sort(cls.primitive_element ** powers)
 
     @property
+    def quadratic_residues(cls) -> "FieldArray":
+        r"""
+        galois.FieldArray: All quadratic residues in the Galois field.
+
+        An element :math:`x` in :math:`\mathrm{GF}(p^m)` is a *quadratic residue* if there exists a :math:`y` such that
+        :math:`y^2 = x` in the field.
+
+        In fields with characteristic 2, every element is a quadratic residue. In fields with characteristic greater than 2,
+        exactly half of the nonzero elements are quadratic residues (and they have two unique square roots).
+
+        See also :func:`FieldArray.is_quadratic_residue`.
+
+        Examples
+        --------
+        .. ipython:: python
+
+            GF = galois.GF(11)
+            GF.quadratic_residues
+
+        .. ipython:: python
+
+            GF = galois.GF(2**4)
+            GF.quadratic_residues
+        """
+        x = cls.Elements()
+        is_quadratic_residue = x.is_quadratic_residue()
+        return x[is_quadratic_residue]
+
+    @property
     def is_prime_field(cls) -> bool:
         """
         bool: Indicates if the field's order is prime.

--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -699,6 +699,35 @@ class FieldClass(FunctionMeta, UfuncMeta):
         return x[is_quadratic_residue]
 
     @property
+    def quadratic_non_residues(cls) -> "FieldArray":
+        r"""
+        galois.FieldArray: All quadratic non-residues in the Galois field.
+
+        An element :math:`x` in :math:`\mathrm{GF}(p^m)` is a *quadratic non-residue* if there does not exist a :math:`y` such that
+        :math:`y^2 = x` in the field.
+
+        In fields with characteristic 2, no elements are quadratic non-residues. In fields with characteristic greater than 2,
+        exactly half of the nonzero elements are quadratic non-residues.
+
+        See also :func:`FieldArray.is_quadratic_residue`.
+
+        Examples
+        --------
+        .. ipython:: python
+
+            GF = galois.GF(11)
+            GF.quadratic_non_residues
+
+        .. ipython:: python
+
+            GF = galois.GF(2**4)
+            GF.quadratic_non_residues
+        """
+        x = cls.Elements()
+        is_quadratic_residue = x.is_quadratic_residue()
+        return x[~is_quadratic_residue]
+
+    @property
     def is_prime_field(cls) -> bool:
         """
         bool: Indicates if the field's order is prime.

--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -6,7 +6,7 @@ FieldClass is also included.
 import inspect
 import math
 import random
-from typing import Tuple, List, Iterable, Optional, Union
+from typing import Tuple, List, Sequence, Iterable, Optional, Union
 from typing_extensions import Literal
 
 import numba
@@ -1188,7 +1188,7 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
     @classmethod
     def Zeros(
         cls,
-        shape: Union[int, Tuple[()], Tuple[int]],
+        shape: Union[int, Sequence[int]],
         dtype: Optional[Union[np.dtype, int, object]] = None
     ) -> "FieldArray":
         """

--- a/tests/fields/test_quadratic_residues.py
+++ b/tests/fields/test_quadratic_residues.py
@@ -1,0 +1,253 @@
+"""
+A pytest module to test the quadratic (non-)residues in finite fields.
+
+Sage:
+    F = GF(79)
+    qr = []
+    qnr = []
+    b = []
+    for x in range(0, F.order()):
+        x = F(x)
+        sqrt_x = sqrt(x)
+        if type(sqrt_x) == type(x):
+            qr.append(x)
+            b.append(True)
+        else:
+            qnr.append(x)
+            b.append(False)
+    print(qr)
+    print(qnr)
+    print(b)
+
+Sage:
+    F = GF(2**3, repr="int")
+    qr = []
+    qnr = []
+    b = []
+    for x in range(0, F.order()):
+        x = F.fetch_int(x)
+        try:
+            sqrt_x = sqrt(x)
+            qr.append(x)
+            b.append(True)
+        except:
+            qnr.append(x)
+            b.append(False)
+    print(qr)
+    print(qnr)
+    print(b)
+"""
+import pytest
+import numpy as np
+
+import galois
+
+
+def test_shapes():
+    GF = galois.GF(31)
+    x = GF.Random()
+    assert isinstance(x.is_quadratic_residue(), np.bool_)
+    x = GF.Random((2,))
+    assert x.is_quadratic_residue().shape == x.shape
+    x = GF.Random((2,2))
+    assert x.is_quadratic_residue().shape == x.shape
+    x = GF.Random((2,2,2))
+    assert x.is_quadratic_residue().shape == x.shape
+
+    GF = galois.GF(2**4)
+    x = GF.Random()
+    assert isinstance(x.is_quadratic_residue(), np.bool_)
+    x = GF.Random((2,))
+    assert x.is_quadratic_residue().shape == x.shape
+    x = GF.Random((2,2))
+    assert x.is_quadratic_residue().shape == x.shape
+    x = GF.Random((2,2,2))
+    assert x.is_quadratic_residue().shape == x.shape
+
+
+def test_binary_field():
+    GF = galois.GF(2)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True])
+    assert isinstance(b, np.ndarray)
+
+
+def test_prime_field_1():
+    GF = galois.GF(7)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 2, 4])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [3, 5, 6])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, True, False, True, False, False])
+    assert isinstance(b, np.ndarray)
+
+
+def test_prime_field_2():
+    GF = galois.GF(31)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 2, 4, 5, 7, 8, 9, 10, 14, 16, 18, 19, 20, 25, 28])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [3, 6, 11, 12, 13, 15, 17, 21, 22, 23, 24, 26, 27, 29, 30])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, True, False, True, True, False, True, True, True, True, False, False, False, True, False, True, False, True, True, True, False, False, False, False, True, False, False, True, False, False])
+    assert isinstance(b, np.ndarray)
+
+
+def test_prime_field_3():
+    GF = galois.GF(79)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 2, 4, 5, 8, 9, 10, 11, 13, 16, 18, 19, 20, 21, 22, 23, 25, 26, 31, 32, 36, 38, 40, 42, 44, 45, 46, 49, 50, 51, 52, 55, 62, 64, 65, 67, 72, 73, 76])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [3, 6, 7, 12, 14, 15, 17, 24, 27, 28, 29, 30, 33, 34, 35, 37, 39, 41, 43, 47, 48, 53, 54, 56, 57, 58, 59, 60, 61, 63, 66, 68, 69, 70, 71, 74, 75, 77, 78])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, True, False, True, True, False, False, True, True, True, True, False, True, False, False, True, False, True, True, True, True, True, True, False, True, True, False, False, False, False, True, True, False, False, False, True, False, True, False, True, False, True, False, True, True, True, False, False, True, True, True, True, False, False, True, False, False, False, False, False, False, True, False, True, True, False, True, False, False, False, False, True, True, False, False, True, False, False])
+    assert isinstance(b, np.ndarray)
+
+
+def test_binary_extension_field_1():
+    GF = galois.GF(2**3)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 2, 3, 4, 5, 6, 7])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, True, True, True, True, True, True])
+    assert isinstance(b, np.ndarray)
+
+
+def test_binary_extension_field_2():
+    GF = galois.GF(2**4)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
+    assert isinstance(b, np.ndarray)
+
+
+def test_binary_extension_field_3():
+    # Use an irreducible, but not primitive, polynomial
+    GF = galois.GF(2**4, irreducible_poly="x^4 + x^3 + x^2 + x + 1")
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
+    assert isinstance(b, np.ndarray)
+
+
+def test_binary_extension_field_4():
+    GF = galois.GF(2**5)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
+    assert isinstance(b, np.ndarray)
+
+
+def test_prime_extension_field_1():
+    GF = galois.GF(3**2)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 2, 4, 8])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [3, 5, 6, 7])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, True, False, True, False, False, False, True])
+    assert isinstance(b, np.ndarray)
+
+
+def test_prime_extension_field_2():
+    GF = galois.GF(3**3)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 6, 7, 8, 9, 11, 12, 13, 15, 16, 20, 22, 25])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [2, 3, 4, 5, 10, 14, 17, 18, 19, 21, 23, 24, 26])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, False, False, False, False, True, True, True, True, False, True, True, True, False, True, True, False, False, False, True, False, True, False, False, True, False])
+    assert isinstance(b, np.ndarray)
+
+
+def test_prime_extension_field_3():
+    GF = galois.GF(5**2)
+    x = GF.Elements()
+
+    qr = GF.quadratic_residues
+    assert np.array_equal(qr, [0, 1, 2, 3, 4, 6, 8, 11, 12, 18, 19, 22, 24])
+    assert type(qr) is GF
+
+    qnr = GF.quadratic_non_residues
+    assert np.array_equal(qnr, [5, 7, 9, 10, 13, 14, 15, 16, 17, 20, 21, 23])
+    assert type(qnr) is GF
+
+    b = x.is_quadratic_residue()
+    assert np.array_equal(b, [True, True, True, True, True, False, True, False, True, False, False, True, True, False, False, False, False, False, True, True, False, False, True, False, True])
+    assert isinstance(b, np.ndarray)


### PR DESCRIPTION
```python
In [1]: import galois

In [2]: GF = galois.GF(11)

In [3]: x = GF.Elements(); x
Out[3]: GF([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10], order=11)

In [4]: x.is_quadratic_residue()
Out[4]: 
array([ True,  True, False,  True,  True,  True, False, False, False,
        True, False])

In [5]: GF.quadratic_residues
Out[5]: GF([0, 1, 3, 4, 5, 9], order=11)

In [6]: GF.quadratic_non_residues
Out[6]: GF([ 2,  6,  7,  8, 10], order=11)
```