### PR TITLE
Support `np.sqrt()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ integer `np.ndarray`. All arithmetic operations follow normal NumPy [broadcastin
 - Exponentiation: `x ** z == np.power(x, z)`, e.g. `x ** 3 == x * x * x`
 - Logarithm: `np.log(x)`, e.g. `GF.primitive_element ** np.log(x) == x`
 - **COMING SOON:** Logarithm base `b`: `GF.log(x, b)`, where `b` is any field element
+- Square root: `r = np.sqrt(x)`, e.g. `r ** 2 == (-r) ** 2 == x`
 - Matrix multiplication: `A @ B == np.matmul(A, B)`
 
 ```python

--- a/docs/api/numpy-examples.rst
+++ b/docs/api/numpy-examples.rst
@@ -1,4 +1,4 @@
-Numpy Examples
+NumPy Examples
 ==============
 
 This section contains examples of some numpy functions when called on Galois field arrays. Many more functions
@@ -33,6 +33,7 @@ Arithmetic
    np.power
    np.square
    np.log
+   np.sqrt
    np.matmul
 
 Advanced Arithmetic

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -127,6 +127,7 @@ integer :obj:`numpy.ndarray`. All arithmetic operations follow normal NumPy `bro
 - Exponentiation: `x ** z == np.power(x, z)`, e.g. `x ** 3 == x * x * x`
 - Logarithm: `np.log(x)`, e.g. `GF.primitive_element ** np.log(x) == x`
 - **COMING SOON:** Logarithm base `b`: `GF.log(x, b)`, where `b` is any field element
+- Square root: `r = np.sqrt(x)`, e.g. `r ** 2 == (-r) ** 2 == x`
 - Matrix multiplication: `A @ B == np.matmul(A, B)`
 
 .. ipython:: python

--- a/galois/_fields/_gf2m.py
+++ b/galois/_fields/_gf2m.py
@@ -217,3 +217,15 @@ class GF2mMeta(FieldClass, DirMeta):
             result = MULTIPLY(result, b, CHARACTERISTIC, DEGREE, IRREDUCIBLE_POLY)
 
         return i
+
+    ###############################################################################
+    # Ufuncs written in NumPy operations (not JIT compiled)
+    ###############################################################################
+
+    @staticmethod
+    def _sqrt(a):
+        """
+        Fact 3.42 from https://cacr.uwaterloo.ca/hac/about/chap3.pdf.
+        """
+        field = type(a)
+        return a ** (field.characteristic**(field.degree - 1))

--- a/galois/_fields/_gfpm.py
+++ b/galois/_fields/_gfpm.py
@@ -336,3 +336,62 @@ class GFpmMeta(FieldClass, DirMeta):
             result = MULTIPLY(result, b, CHARACTERISTIC, DEGREE, IRREDUCIBLE_POLY)
 
         return i
+
+    ###############################################################################
+    # Ufuncs written in NumPy operations (not JIT compiled)
+    ###############################################################################
+
+    @staticmethod
+    def _sqrt(a):
+        """
+        Algorithm 3.34 from https://cacr.uwaterloo.ca/hac/about/chap3.pdf.
+        Algorithm 3.36 from https://cacr.uwaterloo.ca/hac/about/chap3.pdf.
+        """
+        field = type(a)
+        p = field.characteristic
+
+        if p % 4 == 3:
+            roots = a ** ((field.order + 1)//4)
+
+        elif p % 8 == 5:
+            d = a ** ((field.order - 1)//4)
+            roots = field.Zeros(a.shape)
+
+            idxs = np.where(d == 1)
+            roots[idxs] = a[idxs] ** ((field.order + 3)//8)
+
+            idxs = np.where(d == p - 1)
+            roots[idxs] = 2*a[idxs] * (4*a[idxs]) ** ((field.order - 5)//8)
+
+        else:
+            # Find a quadratic non-residue element `b`
+            while True:
+                b = field.Random(low=1)
+                if not b.is_quadratic_residue():
+                    break
+
+            # Write p - 1 = 2^s * t
+            n = field.order - 1
+            s = 0
+            while n % 2 == 0:
+                n >>= 1
+                s += 1
+            t = n
+            assert field.order - 1 == 2**s * t
+
+            roots = field.Zeros(a.shape)  # Empty array of roots
+
+            # Compute a root `r` for the non-zero elements
+            idxs = np.where(a > 0)  # Indices where a has a reciprocal
+            a_inv = np.reciprocal(a[idxs])
+            c = b ** t
+            r = a[idxs] ** ((t + 1)//2)
+            for i in range(1, s):
+                d = (r**2 * a_inv) ** (2**(s - i - 1))
+                r[np.where(d == p - 1)] *= c
+                c = c**2
+            roots[idxs] = r  # Assign non-zero roots to the original array
+
+        roots = np.minimum(roots, -roots).view(field)  # Return only the smaller root
+
+        return roots

--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -687,12 +687,20 @@ class FieldClass(FunctionMeta, UfuncMeta):
         .. ipython:: python
 
             GF = galois.GF(11)
-            GF.quadratic_residues
+            x = GF.quadratic_residues; x
+            r = np.sqrt(x)
+            r, -r
+            r**2
+            (-r)**2
 
         .. ipython:: python
 
             GF = galois.GF(2**4)
-            GF.quadratic_residues
+            x = GF.quadratic_residues; x
+            r = np.sqrt(x)
+            r, -r
+            r**2
+            (-r)**2
         """
         x = cls.Elements()
         is_quadratic_residue = x.is_quadratic_residue()
@@ -2726,6 +2734,14 @@ class GF2Meta(FieldClass, DirMeta):
             raise ArithmeticError("In GF(2), 1 is the only multiplicative generator.")
 
         return 0
+
+    ###############################################################################
+    # Ufuncs written in NumPy operations (not JIT compiled)
+    ###############################################################################
+
+    @staticmethod
+    def _sqrt(a):
+        return a.copy()
 
 
 @set_module("galois")

--- a/np/arithmetic.py
+++ b/np/arithmetic.py
@@ -230,6 +230,35 @@ def log(x):
     return
 
 
+def sqrt(x):
+    """
+    Computes the square root a Galois field array element-wise.
+
+    References
+    ----------
+    * https://numpy.org/doc/stable/reference/generated/numpy.sqrt.html
+
+    Notes
+    -----
+    This function returns the lexicographically-minimal root :math:`r` (the root whose integer representation is smallest).
+    In addition to :math:`r`, :math:`-r` is also a root.
+
+    Examples
+    --------
+    .. ipython:: python
+
+        GF = galois.GF(31)
+        # Only the "quadratic residues" have square roots
+        x = GF.quadratic_residues; x
+        r = np.sqrt(x)
+        # Both roots in the finite field
+        r, -r
+        r**2
+        (-r)**2
+    """
+    return
+
+
 def matmul(x1, x2):
     """
     Computes the matrix multiplication of two Galois field arrays.

--- a/tests/fields/test_sqrt.py
+++ b/tests/fields/test_sqrt.py
@@ -1,0 +1,127 @@
+"""
+A pytest module to test the square roots in finite fields.
+
+Sage:
+    F = GF(7)
+    x = []
+    r = []
+    for xi in range(0, F.order()):
+        xi = F(xi)
+        sqrt_x = sqrt(xi)
+        if type(sqrt_x) == type(xi):
+            x.append(xi)
+            if -sqrt_x < sqrt_x:
+                sqrt_x = -sqrt_x
+            r.append(sqrt_x)
+
+    print(x)
+    print(r)
+
+Sage:
+    F = GF(3**3, repr="int")
+    x = []
+    r = []
+    for xi in range(0, F.order()):
+        xi = F.fetch_int(xi)
+        try:
+            sqrt_x = sqrt(xi)
+            x.append(xi)
+            if -sqrt_x < sqrt_x:
+                sqrt_x = -sqrt_x
+            r.append(sqrt_x)
+        except:
+            pass
+
+    print(x)
+    print(r)
+"""
+import pytest
+import numpy as np
+
+import galois
+
+
+def test_binary_field():
+    GF = galois.GF(2)
+    x = GF([0, 1])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1])
+    assert isinstance(y, GF)
+
+
+def test_prime_field_1():
+    # p % 4 = 3, p % 8 != 5
+    GF = galois.GF(7)
+    x = GF([0, 1, 2, 4])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1, 3, 2])
+    assert isinstance(y, GF)
+
+
+def test_prime_field_2():
+    # p % 4 != 3, p % 8 = 5
+    GF = galois.GF(13)
+    x = GF([0, 1, 3, 4, 9, 10, 12])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1, 4, 2, 3, 6, 5])
+    assert isinstance(y, GF)
+
+
+def test_prime_field_3():
+    # p % 4 != 3, p % 8 != 5
+    GF = galois.GF(17)
+    x = GF([0, 1, 2, 4, 8, 9, 13, 15, 16])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1, 6, 2, 5, 3, 8, 7, 4])
+    assert isinstance(y, GF)
+
+
+def test_binary_extension_field_1():
+    GF = galois.GF(2**3)
+    x = GF([0, 1, 2, 3, 4, 5, 6, 7])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1, 6, 7, 2, 3, 4, 5])
+    assert isinstance(y, GF)
+
+
+def test_binary_extension_field_2():
+    GF = galois.GF(2**4)
+    x = GF([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1, 5, 4, 2, 3, 7, 6, 10, 11, 15, 14, 8, 9, 13, 12])
+    assert isinstance(y, GF)
+
+
+def test_binary_extension_field_3():
+    GF = galois.GF(2**5)
+    x = GF([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1, 27, 26, 2, 3, 25, 24, 19, 18, 8, 9, 17, 16, 10, 11, 4, 5, 31, 30, 6, 7, 29, 28, 23, 22, 12, 13, 21, 20, 14, 15])
+    assert isinstance(y, GF)
+
+
+def test_prime_extension_field_1():
+    # p % 4 = 3, p % 8 != 5
+    GF = galois.GF(3**3)
+    x = GF([0, 1, 6, 7, 8, 9, 11, 12, 13, 15, 16, 20, 22, 25])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1, 17, 10, 14, 3, 13, 16, 5, 9, 4, 15, 12, 11])
+    assert isinstance(y, GF)
+
+
+def test_prime_extension_field_2():
+    # p % 4 != 3, p % 8 = 5
+    GF = galois.GF(5**3)
+    x = GF([0, 1, 4, 6, 7, 10, 11, 13, 15, 17, 19, 23, 24, 25, 27, 28, 34, 36, 37, 39, 40, 41, 42, 44, 45, 46, 47, 49, 52, 53, 56, 60, 61, 62, 64, 66, 70, 71, 77, 78, 80, 84, 89, 90, 91, 93, 94, 99, 100, 102, 103, 105, 106, 108, 109, 110, 111, 113, 114, 116, 118, 119, 121])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1, 2, 42, 46, 62, 29, 74, 31, 37, 53, 67, 59, 5, 49, 35, 8, 6, 58, 27, 66, 9, 61, 52, 34, 73, 40, 7, 57, 32, 72, 25, 43, 38, 65, 51, 47, 60, 64, 41, 69, 30, 28, 50, 45, 71, 56, 36, 10, 70, 68, 63, 14, 55, 39, 48, 26, 33, 13, 54, 44, 12, 11])
+    assert isinstance(y, GF)
+
+
+def test_prime_extension_field_3():
+    # p % 4 != 3, p % 8 != 5
+    GF = galois.GF(17**2)
+    x = GF([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 19, 20, 22, 24, 26, 28, 30, 31, 35, 38, 39, 40, 43, 44, 45, 48, 55, 56, 57, 59, 60, 61, 66, 67, 69, 70, 71, 73, 76, 78, 79, 80, 86, 87, 89, 93, 95, 96, 99, 100, 103, 105, 110, 112, 114, 115, 117, 118, 120, 123, 125, 128, 131, 132, 133, 134, 138, 139, 140, 141, 142, 143, 146, 152, 154, 160, 163, 164, 165, 166, 167, 168, 172, 173, 174, 175, 178, 181, 183, 186, 188, 189, 191, 192, 194, 196, 201, 203, 206, 207, 210, 211, 213, 217, 219, 220, 226, 227, 228, 230, 233, 235, 236, 237, 239, 240, 245, 246, 247, 249, 250, 251, 258, 261, 262, 263, 266, 267, 268, 271, 275, 276, 278, 280, 282, 284, 286, 287])
+    y = np.sqrt(x)
+    assert np.array_equal(y, [0, 1, 6, 116, 2, 58, 50, 83, 5, 3, 25, 149, 91, 8, 124, 7, 4, 81, 148, 61, 135, 109, 86, 46, 17, 42, 129, 79, 64, 98, 26, 102, 147, 38, 123, 93, 67, 112, 146, 18, 77, 75, 88, 105, 34, 145, 134, 53, 27, 19, 128, 47, 144, 115, 73, 100, 56, 43, 59, 95, 143, 71, 108, 122, 28, 90, 69, 20, 62, 118, 39, 142, 133, 127, 141, 84, 29, 35, 111, 85, 65, 97, 51, 121, 140, 82, 21, 48, 104, 114, 44, 139, 132, 92, 80, 30, 54, 78, 107, 126, 22, 40, 57, 87, 138, 99, 60, 31, 120, 36, 137, 117, 76, 74, 94, 110, 49, 136, 131, 63, 23, 32, 72, 45, 125, 89, 66, 103, 152, 41, 119, 70, 52, 101, 24, 113, 151, 68, 150, 55, 130, 106, 96, 37, 33])
+    assert isinstance(y, GF)


### PR DESCRIPTION
### Example

```python
In [1]: import galois

In [2]: import numpy as np

In [3]: GF = galois.GF(13)

In [4]: x = GF.quadratic_residues; x
Out[4]: GF([ 0,  1,  3,  4,  9, 10, 12], order=13)

In [5]: r = np.sqrt(x)

In [6]: r, -r
Out[6]: 
(GF([0, 1, 4, 2, 3, 6, 5], order=13),
 GF([ 0, 12,  9, 11, 10,  7,  8], order=13))

In [7]: r**2
Out[7]: GF([ 0,  1,  3,  4,  9, 10, 12], order=13)

In [8]: (-r)**2
Out[8]: GF([ 0,  1,  3,  4,  9, 10, 12], order=13)
```