### PR TITLE
Fix code coverage exclusion of typing overloads

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,4 +95,4 @@ exclude_lines =
     raise AssertionError
     raise RuntimeError
     raise NotImplementedError
-    ...
+    @overload


### PR DESCRIPTION
fccdf0d686d0c8dfdf6d344220b28fe903d350ce accidentally instructed `pytest-cov` to exclude all source code lines. This PR fixes that. This also fixes codecov.io not working properly as discussed in #255.