### PR TITLE
Internally avoid element verification cost of `.view(GF)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ This library would not be possible without all of the other libraries mentioned.
 
 If this library was useful to you in your research, please cite us. Following the [GitHub citation standards](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files), here is the recommended citation.
 
-### Bibtex
+### BibTeX
 
 ```bibtex
 @software{Hostetter_Galois_2020,

--- a/docs/_static/extra.css
+++ b/docs/_static/extra.css
@@ -15,14 +15,23 @@
 }
 
 /* Override sphinx-design tab-set CSS rules, see https://github.com/jbms/sphinx-immaterial/issues/43 */
-.sd-tab-set>input:checked+label {
-  border-color: var(--md-primary-fg-color);
-  color: var(--md-primary-fg-color);
-}
 .sd-tab-set>input+label {
   font: var(--md-text-font-family);
   font-size: 0.64rem;
+  font-weight: bolder;
+  border-bottom: .13rem solid transparent;
+}
+.sd-tab-set>input:checked+label {
+  border-color: var(--md-accent-fg-color);
+  color: var(--md-accent-fg-color);
+}
+.sd-tab-set>input:not(checked)+label {
+  color: var(--md-default-fg-color--light);
 }
 .sd-tab-set>input:not(:checked)+label:hover {
-  color: var(--md-primary-fg-color);
+  border-bottom: .0rem solid transparent;
+  color: var(--md-accent-fg-color);
+}
+.sd-tab-content {
+  box-shadow: 0 -0.05rem var(--md-default-fg-color--lightest), 0 0.05rem var(--md-default-fg-color--lightest);
 }

--- a/galois/_fields/_functions.py
+++ b/galois/_fields/_functions.py
@@ -145,7 +145,7 @@ class FunctionMeta(UfuncMeta):
             add = cls._func_python("add")
             multiply = cls._func_python("multiply")
             C = cls._function("matmul")(A, B, add, multiply, cls.characteristic, cls.degree, cls._irreducible_poly_int)
-        C = C.view(field)
+        C = field._view(C)
 
         shape = list(C.shape)
         if prepend:
@@ -181,8 +181,7 @@ class FunctionMeta(UfuncMeta):
             b = b.view(np.ndarray).astype(dtype)
             c = np.convolve(a, b)  # Compute result using native numpy LAPACK/BLAS implementation
             c = c % field.characteristic  # Reduce the result mod p
-            c = c.astype(return_dtype).view(field) if not np.isscalar(c) else field(c, dtype=return_dtype)
-            return c
+            c = field._view(c.astype(return_dtype)) if not np.isscalar(c) else field(c, dtype=return_dtype)
         else:
             if cls.ufunc_mode != "python-calculate":
                 a = a.astype(np.int64)
@@ -197,9 +196,9 @@ class FunctionMeta(UfuncMeta):
                 add = cls._func_python("add")
                 multiply = cls._func_python("multiply")
                 c = cls._function("convolve")(a, b, add, multiply, cls.characteristic, cls.degree, cls._irreducible_poly_int)
-            c = c.view(field)
+            c = field._view(c)
 
-            return c
+        return c
 
     def _poly_evaluate(cls, coeffs, x):
         field = cls
@@ -220,7 +219,7 @@ class FunctionMeta(UfuncMeta):
             add = cls._func_python("add")
             multiply = cls._func_python("multiply")
             results = cls._function("poly_evaluate")(coeffs, x, add, multiply, cls.characteristic, cls.degree, cls._irreducible_poly_int)
-        results = results.view(field)
+        results = field._view(results)
         results = results.reshape(shape)
 
         return results
@@ -262,7 +261,7 @@ class FunctionMeta(UfuncMeta):
             multiply = cls._func_python("multiply")
             divide = cls._func_python("divide")
             qr = cls._function("poly_divmod")(a, b, subtract, multiply, divide, cls.characteristic, cls.degree, cls._irreducible_poly_int)
-        qr = qr.view(field)
+        qr = field._view(qr)
 
         q = qr[:, 0:q_degree + 1]
         r = qr[:, q_degree + 1:q_degree + 1 + r_degree + 1]
@@ -294,7 +293,7 @@ class FunctionMeta(UfuncMeta):
             multiply = cls._func_python("multiply")
             divide = cls._func_python("divide")
             q = cls._function("poly_divide")(a, b, subtract, multiply, divide, cls.characteristic, cls.degree, cls._irreducible_poly_int)
-        q = q.view(field)
+        q = field._view(q)
 
         return q
 
@@ -319,7 +318,7 @@ class FunctionMeta(UfuncMeta):
             multiply = cls._func_python("multiply")
             divide = cls._func_python("divide")
             r = cls._function("poly_mod")(a, b, subtract, multiply, divide, cls.characteristic, cls.degree, cls._irreducible_poly_int)
-        r = r.view(field)
+        r = field._view(r)
 
         return r
 
@@ -350,7 +349,7 @@ class FunctionMeta(UfuncMeta):
             convolve = cls._function("convolve")
             poly_mod = cls._function("poly_mod")
             z = cls._function("poly_pow")(a, b, c, add, subtract, multiply, divide, convolve, poly_mod, cls.characteristic, cls.degree, cls._irreducible_poly_int)
-        z = z.view(field)
+        z = field._view(z)
 
         return z
 
@@ -374,7 +373,7 @@ class FunctionMeta(UfuncMeta):
             multiply = cls._func_python("multiply")
             power = cls._func_python("power")
             roots = cls._function("poly_roots")(nonzero_degrees, nonzero_coeffs, int(cls.primitive_element), add, multiply, power, cls.characteristic, cls.degree, cls._irreducible_poly_int)[0,:]
-        roots = roots.view(field)
+        roots = field._view(roots)
 
         idxs = np.argsort(roots)
         return roots[idxs]

--- a/galois/_fields/_gfp.py
+++ b/galois/_fields/_gfp.py
@@ -279,6 +279,6 @@ class GFpMeta(FieldClass, DirMeta):
                 c = c**2
             roots[idxs] = r  # Assign non-zero roots to the original array
 
-        roots = np.minimum(roots, -roots).view(field)  # Return only the smaller root
+        roots = field._view(np.minimum(roots, -roots))  # Return only the smaller root
 
         return roots

--- a/galois/_fields/_gfpm.py
+++ b/galois/_fields/_gfpm.py
@@ -435,6 +435,6 @@ class GFpmMeta(FieldClass, DirMeta):
                 c = c**2
             roots[idxs] = r  # Assign non-zero roots to the original array
 
-        roots = np.minimum(roots, -roots).view(field)  # Return only the smaller root
+        roots = field._view(np.minimum(roots, -roots))  # Return only the smaller root
 
         return roots

--- a/galois/_fields/_linalg.py
+++ b/galois/_fields/_linalg.py
@@ -45,7 +45,7 @@ def _lapack_linalg(a, b, function, out=None, n_sum=None):
         # TODO: Sometimes the scalar c is a float?
         c = field(int(c), dtype=return_dtype)
     else:
-        c = c.astype(return_dtype).view(field)
+        c = field._view(c.astype(return_dtype))
 
     return c
 

--- a/galois/_fields/_ufuncs.py
+++ b/galois/_fields/_ufuncs.py
@@ -176,7 +176,7 @@ class UfuncMeta(LookupMeta, CalculateMeta):
         if isinstance(type(output), field):
             return output
         elif isinstance(output, np.ndarray):
-            return output.astype(dtype).view(field)
+            return field._view(output.astype(dtype))
         elif output is None:
             return None
         else:

--- a/galois/_lfsr.py
+++ b/galois/_lfsr.py
@@ -1005,8 +1005,7 @@ class GLFSR(_LFSR):
 
             .. tab-item:: Scalar output
 
-                Step the Galois LFSR one output at a time. Notice the first :math:`n` outputs of a Galois LFSR are its
-                state reversed.
+                Step the Galois LFSR one output at a time.
 
                 .. ipython:: python
 

--- a/galois/_lfsr.py
+++ b/galois/_lfsr.py
@@ -131,7 +131,7 @@ class _LFSR:
             y = step(taps, state, steps, add, multiply, self.field.characteristic, self.field.degree, self.field._irreducible_poly_int)
 
         self._state[:] = state[:]
-        y = y.view(self.field)
+        y = self.field._view(y)
         if y.size == 1:
             y = y[0]
 
@@ -168,7 +168,7 @@ class _LFSR:
             y = step(taps, state, steps, subtract, multiply, divide, self.field.characteristic, self.field.degree, self.field._irreducible_poly_int)
 
         self._state[:] = state[:]
-        y = y.view(self.field)
+        y = self.field._view(y)
         if y.size == 1:
             y = y[0]
 
@@ -1331,6 +1331,7 @@ def berlekamp_massey(y, output="minimal"):
         divide = field._func_python("divide")
         reciprocal = field._func_python("reciprocal")
         coeffs = python_func("berlekamp_massey")(y, subtract, multiply, divide, reciprocal, field.characteristic, field.degree, field._irreducible_poly_int)
+    coeffs = field._view(coeffs)
 
     characteristic_poly = Poly(coeffs, field=field)
 


### PR DESCRIPTION
This PR implements the proposal from #307. Performance benefits are seen. Here are some examples.

### Single ufunc

```python
In [1]: import galois

In [2]: GF = galois.GF(2**8)

In [3]: x = GF.Random(10_000_000, seed=1); x
Out[3]: GF([255, 228,  34, ..., 146, 176, 223], order=2^8)

In [4]: y = GF.Random(10_000_000, seed=2); y
Out[4]: GF([193,  88, 107, ...,   1, 170,  95], order=2^8)

# Ensure JIT ufuncs are loaded
In [5]: x * y
Out[5]: GF([172,  42,  55, ..., 146,  33,  57], order=2^8)

# Before
In [7]: %timeit x * y
40.5 ms ± 3.02 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# After
In [7]: %timeit x * y
33.8 ms ± 1.64 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

```python
In [1]: import galois

In [2]: GF = galois.GF(2**8)

In [3]: x = GF.Random(10_000_000, seed=1); x
Out[3]: GF([255, 228,  34, ..., 146, 176, 223], order=2^8)

In [4]: y = GF.Random(10_000_000, low=1, seed=2); y
Out[4]: GF([193,  88, 107, ..., 155, 113,  26], order=2^8)

# Ensure JIT functions are loaded
In [5]: x / y
Out[5]: GF([ 46, 215, 152, ...,  65,  82,  44], order=2^8)

# Before
In [8]: %timeit x / y
37.9 ms ± 1.54 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# After
In [7]: %timeit x / y
32.9 ms ± 651 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

### Linear algebra invoking multiple ufuncs

```python
In [1]: import galois

In [2]: GF = galois.GF(2**8)

In [3]: A = GF.Random((100, 100), seed=1)

In [4]: A.row_reduce();

# Before
In [5]: %timeit A.row_reduce();
18.7 ms ± 127 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# After
In [5]: %timeit A.row_reduce();
16.3 ms ± 177 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

### Many polynomial operations

```python
In [1]: import galois

# Ensure JIT functions are loaded
In [2]: galois.primitive_poly(7, 10)
Out[2]: Poly(x^10 + 5x^2 + x + 5, GF(7))

# Before
In [4]: %timeit galois.primitive_poly(7, 10)
447 ms ± 4.82 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# After
In [5]: %timeit galois.primitive_poly(7, 10)
409 ms ± 3.99 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```