### PR TITLE
Speed-up array creation

### DIFF
--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -2393,10 +2393,10 @@ class FieldArray(np.ndarray, metaclass=FieldClass):
         """
         if obj is not None and not isinstance(obj, FieldArray):
             # Only invoked on view casting
-            if obj.dtype not in type(self).dtypes:
-                raise TypeError(f"{type(self).name} can only have integer dtypes {type(self).dtypes}, not {obj.dtype}.")
             if type(self)._verify_on_view:
-                self._check_array_values(obj)
+                if obj.dtype not in type(self).dtypes:
+                    raise TypeError(f"{type(self).name} can only have integer dtypes {type(self).dtypes}, not {obj.dtype}.")
+                self._verify_array_values(obj)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pylint
+pylint<2.13.0
 pytest
 pytest-cov
 pytest-benchmark


### PR DESCRIPTION
## Small fields
```python
In [1]: import galois

In [2]: GF = galois.GF(2**8)
```

### Iterables
```python
# Before
In [3]: %timeit GF([[1, 2], [3, 4], [5, 6]])
72.9 µs ± 280 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# After
In [3]: %timeit GF([[1, 2], [3, 4], [5, 6]])
21 µs ± 11.5 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

### Iterables with strings
```python
# Before
In [4]: %timeit GF([[1, 2], ["x + 1", 4], [5, "x^2 + x"]])
87.4 µs ± 203 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# After
In [4]: %timeit GF([[1, 2], ["x + 1", 4], [5, "x^2 + x"]])
45.7 µs ± 1.23 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

### Scalar
```python
# Before
In [5]: %timeit GF(4)
21.1 µs ± 86.1 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# After
In [5]: %timeit GF(4)
2.85 µs ± 11.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

## Large fields

```python
In [6]: GF = galois.GF(2**100)
```

### Iterables

```python
# Before
In [7]: %timeit GF([[2*60, 3], [4, 2*80], [2**40, 6]])
80.7 µs ± 646 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# After
In [7]: %timeit GF([[2*60, 3], [4, 2*80], [2**40, 6]])
25 µs ± 104 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

### Iterables with strings

```python
# Before
In [8]: %timeit GF([["x^60", 3], ["x^2", 2*80], [2**40, "x^2 + x"]])
98.7 µs ± 493 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# After
In [8]: %timeit GF([["x^60", 3], ["x^2", 2*80], [2**40, "x^2 + x"]])
41 µs ± 1.22 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```