### PR TITLE
Refactor `Poly` class and its inheritance

### DIFF
--- a/galois/_fields/_functions.py
+++ b/galois/_fields/_functions.py
@@ -272,7 +272,7 @@ class FunctionMeta(UfuncMeta):
 
         return q, r
 
-    def _poly_divide(cls, a, b):
+    def _poly_floordiv(cls, a, b):
         assert isinstance(a, cls) and isinstance(b, cls)
         assert a.ndim == 1 and b.ndim == 1
         field = type(a)
@@ -284,7 +284,7 @@ class FunctionMeta(UfuncMeta):
             subtract = cls._func_calculate("subtract")
             multiply = cls._func_calculate("multiply")
             divide = cls._func_calculate("divide")
-            q = cls._function("poly_divide")(a, b, subtract, multiply, divide, cls.characteristic, cls.degree, cls._irreducible_poly_int)
+            q = cls._function("poly_floordiv")(a, b, subtract, multiply, divide, cls.characteristic, cls.degree, cls._irreducible_poly_int)
             q = q.astype(dtype)
         else:
             a = a.view(np.ndarray)
@@ -292,7 +292,7 @@ class FunctionMeta(UfuncMeta):
             subtract = cls._func_python("subtract")
             multiply = cls._func_python("multiply")
             divide = cls._func_python("divide")
-            q = cls._function("poly_divide")(a, b, subtract, multiply, divide, cls.characteristic, cls.degree, cls._irreducible_poly_int)
+            q = cls._function("poly_floordiv")(a, b, subtract, multiply, divide, cls.characteristic, cls.degree, cls._irreducible_poly_int)
         q = field._view(q)
 
         return q
@@ -467,11 +467,11 @@ class FunctionMeta(UfuncMeta):
 
         return qr
 
-    _POLY_DIVIDE_CALCULATE_SIG = numba.types.FunctionType(int64[:](int64[:], int64[:], UfuncMeta._BINARY_CALCULATE_SIG, UfuncMeta._BINARY_CALCULATE_SIG, UfuncMeta._BINARY_CALCULATE_SIG, int64, int64, int64))
+    _POLY_FLOORDIV_CALCULATE_SIG = numba.types.FunctionType(int64[:](int64[:], int64[:], UfuncMeta._BINARY_CALCULATE_SIG, UfuncMeta._BINARY_CALCULATE_SIG, UfuncMeta._BINARY_CALCULATE_SIG, int64, int64, int64))
 
     @staticmethod
     @numba.extending.register_jitable
-    def _poly_divide_calculate(a, b, SUBTRACT, MULTIPLY, DIVIDE, CHARACTERISTIC, DEGREE, IRREDUCIBLE_POLY):
+    def _poly_floordiv_calculate(a, b, SUBTRACT, MULTIPLY, DIVIDE, CHARACTERISTIC, DEGREE, IRREDUCIBLE_POLY):
         args = CHARACTERISTIC, DEGREE, IRREDUCIBLE_POLY
         dtype = a.dtype
 

--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -2862,9 +2862,7 @@ class GF2(FieldArray, metaclass=GF2Meta, characteristic=2, degree=1, order=2, pr
 ###############################################################################
 
 # Values were obtained by running scripts/sparse_poly_performance_test.py
-SPARSE_VS_BINARY_POLY_FACTOR = 0.00_05
-SPARSE_VS_BINARY_POLY_MIN_COEFFS = int(1 / SPARSE_VS_BINARY_POLY_FACTOR)
-SPARSE_VS_DENSE_POLY_FACTOR = 0.00_5
+SPARSE_VS_DENSE_POLY_FACTOR = 0.00_125  # 1.25% density
 SPARSE_VS_DENSE_POLY_MIN_COEFFS = int(1 / SPARSE_VS_DENSE_POLY_FACTOR)
 
 

--- a/galois/_fields/_main.py
+++ b/galois/_fields/_main.py
@@ -708,8 +708,7 @@ class FieldClass(FunctionMeta, UfuncMeta):
             galois.GF(31).irreducible_poly
             galois.GF(7**5).irreducible_poly
         """
-        # Ensure accesses of this property don't alter it
-        return cls._irreducible_poly.copy()
+        return cls._irreducible_poly
 
     @property
     def is_primitive_poly(cls) -> bool:
@@ -3524,17 +3523,6 @@ class Poly:
 
         return coeffs
 
-    def copy(self) -> "Poly":
-        """
-        Deep copies the polynomial.
-
-        Returns
-        -------
-        galois.Poly
-            A copy of the original polynomial.
-        """
-        raise NotImplementedError
-
     def reverse(self) -> "Poly":
         r"""
         Returns the :math:`d`-th reversal :math:`x^d f(\frac{1}{x})` of the polynomial :math:`f(x)` with degree :math:`d`.
@@ -3655,7 +3643,7 @@ class Poly:
             return roots, multiplicities
 
     def _root_multiplicity(self, root):
-        poly = self.copy()
+        poly = self
         multiplicity = 1
 
         while True:
@@ -3667,7 +3655,7 @@ class Poly:
                 # any Galois field, taking `characteristic` derivatives results in p'(x) = 0. For a root with multiplicity
                 # greater than the field's characteristic, we need factor to the polynomial. Here we factor out (x - root)^m,
                 # where m is the current multiplicity.
-                poly = self.copy() // (Poly([1, -root], field=self.field)**multiplicity)
+                poly = self // (Poly([1, -root], field=self.field)**multiplicity)
 
             if poly(root) == 0:
                 multiplicity += 1
@@ -4379,13 +4367,6 @@ class DensePoly(Poly):
         return
 
     ###############################################################################
-    # Methods
-    ###############################################################################
-
-    def copy(self):
-        return DensePoly(self._coeffs.copy())
-
-    ###############################################################################
     # Arithmetic methods
     ###############################################################################
 
@@ -4438,7 +4419,7 @@ class DensePoly(Poly):
             return zero, zero
 
         elif a.degree < b.degree:
-            return zero, a.copy()
+            return zero, a
 
         else:
             q_coeffs, r_coeffs = field._poly_divmod(a.coeffs, b.coeffs)
@@ -4516,18 +4497,11 @@ class BinaryPoly(Poly):
         return
 
     ###############################################################################
-    # Methods
-    ###############################################################################
-
-    def copy(self):
-        return BinaryPoly(self._integer)
-
-    ###############################################################################
     # Arithmetic methods
     ###############################################################################
 
     def __neg__(self):
-        return self.copy()
+        return self
 
     @classmethod
     def _add(cls, a, b):
@@ -4682,9 +4656,6 @@ class SparsePoly(Poly):
     # Methods
     ###############################################################################
 
-    def copy(self):
-        return SparsePoly(self.degrees, self.coeffs)
-
     def reverse(self):
         return SparsePoly(self.degree - self.degrees, self.coeffs)
 
@@ -4749,7 +4720,7 @@ class SparsePoly(Poly):
             return zero, zero
 
         elif a.degree < b.degree:
-            return zero, a.copy()
+            return zero, a
 
         else:
             aa = dict(zip(a.nonzero_degrees, a.nonzero_coeffs))
@@ -4792,7 +4763,7 @@ class SparsePoly(Poly):
             return zero
 
         elif a.degree < b.degree:
-            return a.copy()
+            return a
 
         else:
             aa = dict(zip(a.nonzero_degrees, a.nonzero_coeffs))

--- a/galois/_fields/_poly_functions.py
+++ b/galois/_fields/_poly_functions.py
@@ -415,8 +415,8 @@ def distinct_degree_factorization(poly: Poly) -> Tuple[List[Poly], List[int]]:
     factors_ = []
     degrees = []
 
-    a = poly.copy()
-    h = x.copy()
+    a = poly
+    h = x
 
     l = 1
     while l <= n // 2 and a != one:

--- a/scripts/sparse_poly_performance_test.py
+++ b/scripts/sparse_poly_performance_test.py
@@ -7,49 +7,60 @@ import galois
 
 
 def get_coeffs(degree, N, field):
-    degrees = np.random.randint(0, degree + 1, N, dtype=int)
-    degrees[0] = degree
-    coeffs = field.Random(N, low=1)
-    return degrees, coeffs
+    while True:
+        nonzero_degrees = np.random.randint(0, degree + 1, N, dtype=int)
+        nonzero_degrees[0] = degree
+        nonzero_coeffs = field.Random(N, low=1)
+        if nonzero_degrees.size == np.unique(nonzero_degrees).size:
+            break
+
+    return nonzero_degrees, nonzero_coeffs
 
 
-if True:
-    print("BinaryPoly vs SparsePoly".center(80, "-"))
-    GF = galois.GF2
-    N = 3  # Number of non-zero coefficients
-    degree = 500
-    while degree <= 25_000:
-        print(f"Nonzero: {N} / {degree}, {N/degree*100} %")
-        sp1 = galois.poly.SparsePoly(*get_coeffs(degree, N, GF))
-        sp2 = galois.poly.SparsePoly(*get_coeffs(degree, N, GF))
-        bp1 = galois.poly.BinaryPoly(sp1.integer)
-        bp2 = galois.poly.BinaryPoly(sp2.integer)
-
-        print("  BinaryPoly:\t", end="")
-        ipython.magic("timeit bp1 * bp2")
-
-        print("  SparsePoly:\t", end="")
-        ipython.magic("timeit sp1 * sp2")
-
-        degree *= 2
+GF = galois.GF(2**8)
 
 
-if True:
-    print("DensePoly vs SparsePoly".center(80, "-"))
-    GF = galois.GF(31)
-    N = 3  # Number of non-zero coefficients
-    degree = 500
-    while degree <= 25_000:
-        print(f"Nonzero: {N} / {degree}, {N/degree*100} %")
-        sp1 = galois.poly.SparsePoly(*get_coeffs(degree, N, GF))
-        sp2 = galois.poly.SparsePoly(*get_coeffs(degree, N, GF))
-        dp1 = galois.poly.BinaryPoly(sp1.integer)
-        dp2 = galois.poly.BinaryPoly(sp2.integer)
+# print("DensePoly vs SparsePoly Addition".center(80, "-"))
+# N = 3  # Number of non-zero coefficients
+# degree = 2000
+# while degree <= 32000:
+#     print(f"Nonzero: {N} / {degree}, {N/degree*100} %")
+#     p1 = galois.Poly.Degrees(*get_coeffs(degree, N, GF))
+#     p2 = galois.Poly.Degrees(*get_coeffs(degree, N, GF))
 
-        print("  DensePoly:\t", end="")
-        ipython.magic("timeit dp1 * dp2")
+#     print("  SparsePoly:\t", end="")
+#     p1._type = "sparse"
+#     p2._type = "sparse"
+#     p1.nonzero_degrees, p1.nonzero_coeffs, p2.nonzero_degrees, p2.nonzero_coeffs
+#     ipython.run_line_magic("timeit", "p1 + p2")
 
-        print("  SparsePoly:\t", end="")
-        ipython.magic("timeit sp1 * sp2")
+#     print("  DensePoly:\t", end="")
+#     p1._type = "dense"
+#     p2._type = "dense"
+#     p1.coeffs, p2.coeffs  # Ensure _coeffs is created for arithmetic
+#     ipython.run_line_magic("timeit", "p1 + p2")
 
-        degree *= 2
+#     degree *= 2
+
+
+print("DensePoly vs SparsePoly Multiplication".center(80, "-"))
+N = 3  # Number of non-zero coefficients
+degree = 100
+while degree <= 1000:
+    print(f"Nonzero: {N} / {degree}, {N/degree*100} %")
+    p1 = galois.Poly.Degrees(*get_coeffs(degree, N, GF))
+    p2 = galois.Poly.Degrees(*get_coeffs(degree, N, GF))
+
+    print("  SparsePoly:\t", end="")
+    p1._type = "sparse"
+    p2._type = "sparse"
+    p1.nonzero_degrees, p1.nonzero_coeffs, p2.nonzero_degrees, p2.nonzero_coeffs
+    ipython.run_line_magic("timeit", "p1 * p2")
+
+    print("  DensePoly:\t", end="")
+    p1._type = "dense"
+    p2._type = "dense"
+    p1.coeffs, p2.coeffs  # Ensure _coeffs is created for arithmetic
+    ipython.run_line_magic("timeit", "p1 * p2")
+
+    degree += 100

--- a/tests/polys/test_arithmetic_implementations.py
+++ b/tests/polys/test_arithmetic_implementations.py
@@ -1,5 +1,5 @@
 """
-A pytest module to test polynomial arithmetic implemented with DensePoly, BinaryPoly, and SparsePoly.
+A pytest module to test polynomial arithmetic using the "binary" and "sparse" implementations.
 
 We don't need to verify the arithmetic is correct (that was already done in test_arithmetic.py). We
 just need to make sure the arithmetic is the same for the different implementations.
@@ -7,49 +7,137 @@ just need to make sure the arithmetic is the same for the different implementati
 import random
 
 import galois
-from galois._fields._main import DensePoly, BinaryPoly, SparsePoly
 
 
 def test_add(field):
     a = galois.Poly.Random(random.randint(0, 5))
     b = galois.Poly.Random(random.randint(0, 5))
+
+    f_dense = a + b
+
+    # Ensure the nonzero properties are created
+    a.nonzero_degrees, a.nonzero_coeffs, b.nonzero_degrees, b.nonzero_coeffs
+    a._type = "sparse"; b._type = "sparse"
+    f_sparse = a + b
+    assert f_sparse == f_dense
+
     if field is galois.GF2:
-        assert BinaryPoly._add(a, b) == DensePoly._add(a, b) == SparsePoly._add(a, b)
-    else:
-        assert DensePoly._add(a, b) == SparsePoly._add(a, b)
+        int(a), int(b)
+        a._type = "binary"; b._type = "binary"
+        f_binary = a + b
+        assert f_binary == f_dense
+
+
+def test_neg(field):
+    a = galois.Poly.Random(random.randint(0, 5))
+
+    f_dense = -a
+
+    # Ensure the nonzero properties are created
+    a.nonzero_degrees, a.nonzero_coeffs
+    a._type = "sparse"
+    f_sparse = -a
+    assert f_sparse == f_dense
+
+    if field is galois.GF2:
+        int(a)
+        a._type = "binary"
+        f_binary = -a
+        assert f_binary == f_dense
 
 
 def test_subtract(field):
     a = galois.Poly.Random(random.randint(0, 5))
     b = galois.Poly.Random(random.randint(0, 5))
+
+    f_dense = a - b
+
+    # Ensure the nonzero properties are created
+    a.nonzero_degrees, a.nonzero_coeffs, b.nonzero_degrees, b.nonzero_coeffs
+    a._type = "sparse"; b._type = "sparse"
+    f_sparse = a - b
+    assert f_sparse == f_dense
+
     if field is galois.GF2:
-        assert BinaryPoly._sub(a, b) == DensePoly._sub(a, b) == SparsePoly._sub(a, b)
-    else:
-        assert DensePoly._sub(a, b) == SparsePoly._sub(a, b)
+        int(a), int(b)
+        a._type = "binary"; b._type = "binary"
+        f_binary = a - b
+        assert f_binary == f_dense
 
 
 def test_multiply(field):
     a = galois.Poly.Random(random.randint(0, 5))
     b = galois.Poly.Random(random.randint(0, 5))
+
+    f_dense = a * b
+
+    # Ensure the nonzero properties are created
+    a.nonzero_degrees, a.nonzero_coeffs, b.nonzero_degrees, b.nonzero_coeffs
+    a._type = "sparse"; b._type = "sparse"
+    f_sparse = a * b
+    assert f_sparse == f_dense
+
     if field is galois.GF2:
-        assert BinaryPoly._mul(a, b) == DensePoly._mul(a, b) == SparsePoly._mul(a, b)
-    else:
-        assert DensePoly._mul(a, b) == SparsePoly._mul(a, b)
+        int(a), int(b)
+        a._type = "binary"; b._type = "binary"
+        f_binary = a * b
+        assert f_binary == f_dense
 
 
 def test_divmod(field):
     a = galois.Poly.Random(random.randint(0, 5))
     b = galois.Poly.Random(random.randint(0, 5))
+
+    q_dense, r_dense = divmod(a, b)
+
+    # Ensure the nonzero properties are created
+    a.nonzero_degrees, a.nonzero_coeffs, b.nonzero_degrees, b.nonzero_coeffs
+    a._type = "sparse"; b._type = "sparse"
+    q_sparse, r_sparse = divmod(a, b)
+    assert q_sparse == q_dense
+    assert r_sparse == r_dense
+
     if field is galois.GF2:
-        assert BinaryPoly._divmod(a, b) == DensePoly._divmod(a, b) == SparsePoly._divmod(a, b)
-    else:
-        assert DensePoly._divmod(a, b) == SparsePoly._divmod(a, b)
+        int(a), int(b)
+        a._type = "binary"; b._type = "binary"
+        q_binary, r_binary = divmod(a, b)
+        assert q_binary == q_dense
+        assert r_binary == r_dense
+
+
+def test_floordiv(field):
+    a = galois.Poly.Random(random.randint(0, 5))
+    b = galois.Poly.Random(random.randint(0, 5))
+
+    f_dense = a // b
+
+    # Ensure the nonzero properties are created
+    a.nonzero_degrees, a.nonzero_coeffs, b.nonzero_degrees, b.nonzero_coeffs
+    a._type = "sparse"; b._type = "sparse"
+    f_sparse = a // b
+    assert f_sparse == f_dense
+
+    if field is galois.GF2:
+        int(a), int(b)
+        a._type = "binary"; b._type = "binary"
+        f_binary = a // b
+        assert f_binary == f_dense
 
 
 def test_mod(field):
     a = galois.Poly.Random(random.randint(0, 5))
     b = galois.Poly.Random(random.randint(0, 5))
+
+    f_dense = a % b
+
+    # Ensure the nonzero properties are created
+    a.nonzero_degrees, a.nonzero_coeffs, b.nonzero_degrees, b.nonzero_coeffs
+    a._type = "sparse"; b._type = "sparse"
+    f_sparse = a % b
+    assert f_sparse == f_dense
+
     if field is galois.GF2:
-        assert BinaryPoly._mod(a, b) == DensePoly._mod(a, b) == SparsePoly._mod(a, b)
-    else:
-        assert DensePoly._mod(a, b) == SparsePoly._mod(a, b)
+        int(a), int(b)
+        a._type = "binary"; b._type = "binary"
+        f_binary = a % b
+        assert f_binary == f_dense

--- a/tests/polys/test_conversions.py
+++ b/tests/polys/test_conversions.py
@@ -61,10 +61,10 @@ def test_sparse_poly_to_str():
     GF = galois.GF(2**8)
     with GF.display("poly"):
         assert galois._poly_conversion.sparse_poly_to_str([0], GF([0])) == "0"
-        assert galois._poly_conversion.sparse_poly_to_str([3, 1, 0], GF([1, 2, 3])) == "x^3 + (α)x + (α + 1)"
+        assert galois._poly_conversion.sparse_poly_to_str([3, 1, 0], GF([1, 2, 3])) == "x^3 + (α)x + α + 1"
 
         assert galois._poly_conversion.sparse_poly_to_str([0], GF([0]), poly_var="y") == "0"
-        assert galois._poly_conversion.sparse_poly_to_str([3, 1, 0], GF([1, 2, 3]), poly_var="y") == "y^3 + (α)y + (α + 1)"
+        assert galois._poly_conversion.sparse_poly_to_str([3, 1, 0], GF([1, 2, 3]), poly_var="y") == "y^3 + (α)y + α + 1"
 
 
 def test_str_to_sparse_poly():

--- a/tests/polys/test_operations.py
+++ b/tests/polys/test_operations.py
@@ -196,9 +196,9 @@ def test_len():
     assert p._type == "binary"
     assert len(p) == 1
 
-    p = galois.Poly.Str("x^1000 + 1", field=GF)
+    p = galois.Poly.Str("x^2000 + 1", field=GF)
     assert p._type == "sparse"
-    assert len(p) == 1001
+    assert len(p) == 2001
 
 
 def test_immutable():

--- a/tests/polys/test_operations.py
+++ b/tests/polys/test_operations.py
@@ -60,54 +60,54 @@ def test_reverse():
 
 def test_repr():
     GF = galois.GF2
-    poly = galois.Poly([1,0,1,1])
+    poly = galois.Poly([1, 0, 1, 1])
     assert repr(poly) == "Poly(x^3 + x + 1, GF(2))"
     with GF.display("poly"):
-        assert repr(poly) == "Poly(x^3 + x + (1), GF(2))"  # TODO: Clean this up
+        assert repr(poly) == "Poly(x^3 + x + 1, GF(2))"
     with GF.display("power"):
-        assert repr(poly) == "Poly(x^3 + x + (1), GF(2))"  # TODO: Clean this up
+        assert repr(poly) == "Poly(x^3 + x + 1, GF(2))"
 
     GF = galois.GF(7)
-    poly = galois.Poly([5,0,3,1], field=GF)
+    poly = galois.Poly([5, 0, 3, 1], field=GF)
     assert repr(poly) == "Poly(5x^3 + 3x + 1, GF(7))"
     with GF.display("poly"):
-        assert repr(poly) == "Poly((5)x^3 + (3)x + (1), GF(7))"  # TODO: Clean this up
+        assert repr(poly) == "Poly((5)x^3 + (3)x + 1, GF(7))"
     with GF.display("power"):
-        assert repr(poly) == "Poly((α^5)x^3 + (α)x + (1), GF(7))"
+        assert repr(poly) == "Poly((α^5)x^3 + (α)x + 1, GF(7))"
 
     GF = galois.GF(2**3)
-    poly = galois.Poly([2,0,3,1], field=GF)
+    poly = galois.Poly([2, 0, 3, 1], field=GF)
     assert repr(poly) == "Poly(2x^3 + 3x + 1, GF(2^3))"
     with GF.display("poly"):
-        assert repr(poly) == "Poly((α)x^3 + (α + 1)x + (1), GF(2^3))"
+        assert repr(poly) == "Poly((α)x^3 + (α + 1)x + 1, GF(2^3))"
     with GF.display("power"):
-        assert repr(poly) == "Poly((α)x^3 + (α^3)x + (1), GF(2^3))"
+        assert repr(poly) == "Poly((α)x^3 + (α^3)x + 1, GF(2^3))"
 
 
 def test_str():
     GF = galois.GF2
-    poly = galois.Poly([1,0,1,1])
+    poly = galois.Poly([1, 0, 1, 1])
     assert str(poly) == "x^3 + x + 1"
     with GF.display("poly"):
-        assert str(poly) == "x^3 + x + (1)"  # TODO: Clean this up
+        assert str(poly) == "x^3 + x + 1"
     with GF.display("power"):
-        assert str(poly) == "x^3 + x + (1)"  # TODO: Clean this up
+        assert str(poly) == "x^3 + x + 1"
 
     GF = galois.GF(7)
-    poly = galois.Poly([5,0,3,1], field=GF)
+    poly = galois.Poly([5, 0, 3, 1], field=GF)
     assert str(poly) == "5x^3 + 3x + 1"
     with GF.display("poly"):
-        assert str(poly) == "(5)x^3 + (3)x + (1)"  # TODO: Clean this up
+        assert str(poly) == "(5)x^3 + (3)x + 1"
     with GF.display("power"):
-        assert str(poly) == "(α^5)x^3 + (α)x + (1)"
+        assert str(poly) == "(α^5)x^3 + (α)x + 1"
 
     GF = galois.GF(2**3)
-    poly = galois.Poly([2,0,3,1], field=GF)
+    poly = galois.Poly([2, 0, 3, 1], field=GF)
     assert str(poly) == "2x^3 + 3x + 1"
     with GF.display("poly"):
-        assert str(poly) == "(α)x^3 + (α + 1)x + (1)"
+        assert str(poly) == "(α)x^3 + (α + 1)x + 1"
     with GF.display("power"):
-        assert str(poly) == "(α)x^3 + (α^3)x + (1)"
+        assert str(poly) == "(α)x^3 + (α^3)x + 1"
 
 
 def test_int():

--- a/tests/polys/test_operations.py
+++ b/tests/polys/test_operations.py
@@ -44,26 +44,6 @@ def test_coefficients():
     assert type(coeffs) is GF
 
 
-def test_copy():
-    p1 = galois.Poly([2,0,1,2], field=galois.GF(3))
-    assert isinstance(p1, DensePoly)
-    p2 = p1.copy()
-    p2._coeffs[0] = 0
-    assert np.array_equal(p1.coeffs, [2,0,1,2])
-
-    p1 = galois.Poly([1,0,1,1])
-    assert isinstance(p1, BinaryPoly)
-    p2 = p1.copy()
-    p2._integer = 27
-    assert np.array_equal(p1.coeffs, [1,0,1,1])
-
-    p1 = galois.Poly.Degrees([3000,1,0], [1,2,1], field=galois.GF(3))
-    assert isinstance(p1, SparsePoly)
-    p2 = p1.copy()
-    p2._degrees[0] = 4000
-    assert np.array_equal(p1.nonzero_degrees, [3000,1,0])
-
-
 def test_reverse():
     p1 = galois.Poly([2,0,1,2], field=galois.GF(3))
     p2 = galois.Poly([2,1,0,2], field=galois.GF(3))
@@ -207,3 +187,12 @@ def test_len():
     # SparsePoly
     p = galois.Poly.Str("x^1000 + 1")
     assert len(p) == 1001
+
+
+def test_immutable():
+    GF = galois.GF(7)
+    f = galois.Poly([1, 2, 3], field=GF)
+    h = f
+    f += GF(1)
+    assert f == galois.Poly([1, 2, 4], field=GF)
+    assert h == galois.Poly([1, 2, 3], field=GF)


### PR DESCRIPTION
This PR implements #176. As a consequence of removing `DensePoly`, `BinaryPoly`, and `SparsePoly` and consolidating them into `Poly`, binary array arithmetic/creation is much faster. Below are some examples.

### Polynomial arithmetic over GF(2)

```python
In [1]: import galois

In [2]: f = galois.Poly.Random(20, seed=1); f
Out[2]: Poly(x^20 + x^19 + x^16 + x^15 + x^13 + x^11 + x^9 + x^8 + x^7 + x^5 + x^4 + x^2 + 1, GF(2))

In [3]: g = galois.Poly.Random(10, seed=1); g
Out[3]: Poly(x^10 + x^9 + x^6 + x^5 + x^3 + x, GF(2))

In [4]: f * g
Out[4]: Poly(x^30 + x^28 + x^22 + x^20 + x^19 + x^13 + x^11 + x^10 + x^9 + x^8 + x^5 + x, GF(2))
```

```python
# Before
In [5]: %timeit f * g
196 µs ± 11.4 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

# After
In [5]: %timeit f * g
2.66 µs ± 13 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

### Polynomial search routines in GF(2)

```python
# Before
In [4]: %timeit galois.primitive_polys(2, 12)
10.1 s ± 123 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# After
In [2]: %timeit galois.primitive_polys(2, 12)
783 ms ± 1.53 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```