### PR TITLE
Fix missing function signatures

### DIFF
--- a/galois/_codes/_bch.py
+++ b/galois/_codes/_bch.py
@@ -306,7 +306,7 @@ class BCH:
 
         return string
 
-    def encode(self, message: Union[np.ndarray, GF2], parity_only: bool = False) -> Union[np.ndarray, GF2]:
+    def encode(self, message: Union[np.ndarray, "GF2"], parity_only: bool = False) -> Union[np.ndarray, "GF2"]:
         r"""
         Encodes the message :math:`\mathbf{m}` into the BCH codeword :math:`\mathbf{c}`.
 
@@ -438,7 +438,7 @@ class BCH:
             codeword = message.view(GF2) @ self.G
             return codeword.view(type(message))
 
-    def detect(self, codeword: Union[np.ndarray, GF2]) -> Union[np.bool_, np.ndarray]:
+    def detect(self, codeword: Union[np.ndarray, "GF2"]) -> Union[np.bool_, np.ndarray]:
         r"""
         Detects if errors are present in the BCH codeword :math:`\mathbf{c}`.
 

--- a/galois/_codes/_cyclic.py
+++ b/galois/_codes/_cyclic.py
@@ -1,6 +1,8 @@
 """
 A module containing common functions for cyclic codes.
 """
+from __future__ import annotations
+
 import numpy as np
 
 from .._fields import FieldArray
@@ -11,7 +13,7 @@ __all__ = ["poly_to_generator_matrix", "roots_to_parity_check_matrix"]
 
 
 @set_module("galois")
-def poly_to_generator_matrix(n: int, generator_poly: Poly, systematic: bool = True) -> FieldArray:
+def poly_to_generator_matrix(n: int, generator_poly: "Poly", systematic: bool = True) -> "FieldArray":
     r"""
     Converts the generator polynomial :math:`g(x)` into the generator matrix :math:`\mathbf{G}` for an :math:`[n, k]` cyclic code.
 
@@ -74,7 +76,7 @@ def poly_to_generator_matrix(n: int, generator_poly: Poly, systematic: bool = Tr
 
 
 @set_module("galois")
-def roots_to_parity_check_matrix(n: int, roots: FieldArray) -> FieldArray:
+def roots_to_parity_check_matrix(n: int, roots: "FieldArray") -> "FieldArray":
     r"""
     Converts the generator polynomial roots into the parity-check matrix :math:`\mathbf{H}` for an :math:`[n, k]` cyclic code.
 

--- a/galois/_codes/_linear.py
+++ b/galois/_codes/_linear.py
@@ -1,6 +1,8 @@
 """
 A module containing common functions for linear block codes.
 """
+from __future__ import annotations
+
 import numpy as np
 
 from .._fields import FieldArray
@@ -10,7 +12,7 @@ __all__ = ["generator_to_parity_check_matrix", "parity_check_to_generator_matrix
 
 
 @set_module("galois")
-def generator_to_parity_check_matrix(G: FieldArray) -> FieldArray:
+def generator_to_parity_check_matrix(G: "FieldArray") -> "FieldArray":
     r"""
     Converts the generator matrix :math:`\mathbf{G}` of a linear :math:`[n, k]` code into its parity-check matrix :math:`\mathbf{H}`.
 
@@ -52,7 +54,7 @@ def generator_to_parity_check_matrix(G: FieldArray) -> FieldArray:
 
 
 @set_module("galois")
-def parity_check_to_generator_matrix(H: FieldArray) -> FieldArray:
+def parity_check_to_generator_matrix(H: "FieldArray") -> "FieldArray":
     r"""
     Converts the parity-check matrix :math:`\mathbf{H}` of a linear :math:`[n, k]` code into its generator matrix :math:`\mathbf{G}`.
 

--- a/galois/_codes/_reed_solomon.py
+++ b/galois/_codes/_reed_solomon.py
@@ -195,7 +195,7 @@ class ReedSolomon:
 
         return string
 
-    def encode(self, message: Union[np.ndarray, FieldArray], parity_only: bool = False) -> Union[np.ndarray, FieldArray]:
+    def encode(self, message: Union[np.ndarray, "FieldArray"], parity_only: bool = False) -> Union[np.ndarray, "FieldArray"]:
         r"""
         Encodes the message :math:`\mathbf{m}` into the Reed-Solomon codeword :math:`\mathbf{c}`.
 
@@ -327,7 +327,7 @@ class ReedSolomon:
             codeword = message.view(self.field) @ self.G
             return codeword.view(type(message))
 
-    def detect(self, codeword: Union[np.ndarray, FieldArray]) -> Union[np.bool_, np.ndarray]:
+    def detect(self, codeword: Union[np.ndarray, "FieldArray"]) -> Union[np.bool_, np.ndarray]:
         r"""
         Detects if errors are present in the Reed-Solomon codeword :math:`\mathbf{c}`.
 
@@ -484,10 +484,10 @@ class ReedSolomon:
         return detected
 
     @overload
-    def decode(self, codeword: Union[np.ndarray, FieldArray], errors: Literal[False]) -> Union[np.ndarray, FieldArray]:
+    def decode(self, codeword: Union[np.ndarray, "FieldArray"], errors: Literal[False]) -> Union[np.ndarray, "FieldArray"]:
         ...
     @overload
-    def decode(self, codeword: Union[np.ndarray, FieldArray], errors: Literal[True]) -> Tuple[Union[np.ndarray, FieldArray], Union[np.integer, np.ndarray]]:
+    def decode(self, codeword: Union[np.ndarray, "FieldArray"], errors: Literal[True]) -> Tuple[Union[np.ndarray, "FieldArray"], Union[np.integer, np.ndarray]]:
         ...
     def decode(self, codeword, errors=False):
         r"""

--- a/galois/_lfsr.py
+++ b/galois/_lfsr.py
@@ -472,7 +472,7 @@ class FLFSR(_LFSR):
         # pylint: disable=useless-super-delegation
         return super().reset(state)
 
-    def step(self, steps: int = 1) -> FieldArray:
+    def step(self, steps: int = 1) -> "FieldArray":
         """
         Produces the next `steps` output symbols.
 
@@ -991,7 +991,7 @@ class GLFSR(_LFSR):
         # pylint: disable=useless-super-delegation
         return super().reset(state)
 
-    def step(self, steps: int = 1) -> FieldArray:
+    def step(self, steps: int = 1) -> "FieldArray":
         """
         Produces the next `steps` output symbols.
 

--- a/galois/_ntt.py
+++ b/galois/_ntt.py
@@ -20,7 +20,7 @@ def ntt(
     x: ArrayLike,
     size: Optional[int] = None,
     modulus: Optional[int] = None
-) -> FieldArray:
+) -> "FieldArray":
     r"""
     Computes the Number-Theoretic Transform (NTT) of :math:`x`.
 
@@ -131,7 +131,7 @@ def intt(
     size: Optional[int] = None,
     modulus: Optional[int] = None,
     scaled: bool = True
-) -> FieldArray:
+) -> "FieldArray":
     r"""
     Computes the Inverse Number-Theoretic Transform (INTT) of :math:`X`.
 


### PR DESCRIPTION
For who knows what reason, Sphinx will sometimes **completely omit** a function/method signature if a type hint isn't forward referenced. These only apply to `galois` classes, it seems.

Because of this *silent error*, there were some missing signatures in the docs from the last release. This PR should add them back in.

Sphinx is a terribly frustrating tool........