### PR TITLE
Always return `int` from `Poly.degree`

### DIFF
--- a/galois/_polys/_poly.py
+++ b/galois/_polys/_poly.py
@@ -1513,7 +1513,7 @@ class Poly:
                 if self._nonzero_degrees.size == 0:
                     self._degree = 0
                 else:
-                    self._degree = max(self._nonzero_degrees)
+                    self._degree = int(max(self._nonzero_degrees))
             elif hasattr(self, "_integer"):
                 if self._integer == 0:
                     self._degree = 0

--- a/tests/polys/test_irreducible_polys.py
+++ b/tests/polys/test_irreducible_polys.py
@@ -111,3 +111,11 @@ def test_irreducible_polys_exceptions():
 def test_irreducible_polys(order, degree):
     LUT = eval(f"IRREDUCIBLE_POLYS_{order}_{degree}")
     assert [f.coeffs.tolist() for f in galois.irreducible_polys(order, degree)] == LUT
+
+
+def test_large_degree():
+    """
+    See https://github.com/mhostetter/galois/issues/360.
+    """
+    f = galois.Poly.Degrees([233, 74, 0])
+    assert galois.is_irreducible(f)


### PR DESCRIPTION
Fixes #360. In certain circumstances a `np.int64` was returned from `Poly.degree`. When performing irreducibility checks and computing `q**m`, if either `q` or `m` wasn't an `int` the arithmetic could overflow and the irreducibility check became erroneous.

Now, #360 runs as follows:

```python
# test_2.py
import galois

f = galois.Poly.Degrees([233, 74, 0])
print(galois.is_irreducible(f))

#initial detection loop
for k in range(1, 233):
    poly = galois.Poly.Degrees([233, k, 0])
    if galois.is_irreducible(poly):
        print("Found one: ", k, poly)
```

```python
In [1]: %run test_2.py
True
Found one:  74 x^233 + x^74 + 1
Found one:  159 x^233 + x^159 + 1

In [2]: 
```