### PR TITLE
Pollard-rho discrete logarithm

### DIFF
--- a/galois/_domains/_meta.py
+++ b/galois/_domains/_meta.py
@@ -65,6 +65,8 @@ class ArrayMeta(abc.ABCMeta):
         # By default, verify array elements are within the valid range when `.view()` casting
         cls._verify_on_view = True
 
+        cls._assign_ufuncs()
+
     def __dir__(cls) -> List[str]:
         """
         Add class properties from the metaclass onto the new Array class's dir().
@@ -86,6 +88,10 @@ class ArrayMeta(abc.ABCMeta):
         if len(dtypes) == 0:
             dtypes = [np.object_]
         return dtypes
+
+    def _assign_ufuncs(cls):
+        # This will be implemented in UFuncMixin and its children
+        return
 
     ###############################################################################
     # View methods

--- a/galois/_domains/_ufunc.py
+++ b/galois/_domains/_ufunc.py
@@ -107,6 +107,10 @@ class UFunc:
         self._CACHE_LOOKUP.setdefault(key_1, {})
 
         if key_2 not in self._CACHE_LOOKUP[key_1]:
+            # Ensure the lookup tables were created
+            assert self.field._EXP.size > 0
+            assert self.field._LOG.size > 0
+            assert self.field._ZECH_LOG.size > 0
             self.set_lookup_globals()  # Set the globals once before JIT compiling the function
 
             if self.type == "unary":

--- a/galois/_domains/_ufunc.py
+++ b/galois/_domains/_ufunc.py
@@ -533,8 +533,8 @@ class UFuncMixin(np.ndarray, metaclass=ArrayMeta):
     _square: UFunc
     _matmul: UFunc
 
-    def __init_subclass__(cls) -> None:
-        super().__init_subclass__()
+    @classmethod
+    def _assign_ufuncs(cls):
         cls._divmod = divmod_ufunc(cls)
         cls._remainder = remainder_ufunc(cls)
         cls._square = square_ufunc(cls)

--- a/tests/fields/test_arithmetic.py
+++ b/tests/fields/test_arithmetic.py
@@ -214,6 +214,35 @@ def test_log_different_base(field_log):
     assert np.array_equal(beta ** z, x)
 
 
+def test_log_pollard_rho():
+    GF = galois.GF(2**19, compile="jit-calculate")
+    assert isinstance(GF._log, galois._domains._calculate.log_pollard_rho)
+    dtype = random.choice(GF.dtypes)
+    x = GF.Random(10, low=1, dtype=dtype)
+
+    alpha = GF.primitive_element
+    z = np.log(x)
+    assert np.array_equal(alpha ** z, x)
+    z = x.log()
+    assert np.array_equal(alpha ** z, x)
+
+    beta = GF.primitive_elements[-1]
+    z = x.log(beta)
+    assert np.array_equal(beta ** z, x)
+
+
+# TODO: Skip slow log() for very large fields
+# def test_log_pollard_rho_python():
+#     GF = galois.GF(2**61)
+#     assert isinstance(GF._log, galois._domains._calculate.log_pollard_rho)
+#     dtype = random.choice(GF.dtypes)
+#     x = GF.Random(low=1, dtype=dtype)
+
+#     alpha = GF.primitive_element
+#     z = x.log()
+#     assert np.array_equal(alpha ** z, x)
+
+
 # class TestArithmeticNonField:
 
 


### PR DESCRIPTION
The Pollard-rho discrete logarithm algorithm is only applicable to multiplicative groups with prime order. That ends up being only some `GF(2^m)` fields. There is a large performance bump, though. 🚀 

### Before

```python
In [1]: import galois

In [2]: GF = galois.GF(2**19, compile="jit-calculate")

In [3]: GF._log
Out[3]: <galois._domains._calculate.log_brute_force at 0x7fc1419f7430>

In [4]: x = GF.Random(100, low=1, seed=1)

In [5]: x.log();

In [6]: %timeit x.log()
82.2 ms ± 229 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

### After

```python
In [1]: import galois

In [2]: GF = galois.GF(2**19, compile="jit-calculate")

In [3]: GF._log
Out[3]: <galois._domains._calculate.log_pollard_rho at 0x7fdba7d8a2e0>

In [4]: x = GF.Random(100, low=1, seed=1)

In [5]: x.log();

In [6]: %timeit x.log()
4.63 ms ± 11.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```