### PR TITLE
Use "square" terminology instead of "quadratic residue"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ all arithmetic is performed in $\mathrm{GF}(p^m)$, not $\mathbb{R}$.
 
 Internally, the finite field arithmetic is implemented by replacing [NumPy ufuncs](https://numpy.org/doc/stable/reference/ufuncs.html).
 The new ufuncs are written in pure Python and [just-in-time compiled](https://numba.pydata.org/numba-doc/dev/user/vectorize.html) with
-[Numba](https://numba.pydata.org/). The ufuncs can be configured to use either lookup tables (for speed) or explicit calculation (for memory savings). 
+[Numba](https://numba.pydata.org/). The ufuncs can be configured to use either lookup tables (for speed) or explicit calculation (for memory savings).
 
 | :warning: Disclaimer    |
 |:------------------------|

--- a/docs/basic-usage/array-arithmetic.rst
+++ b/docs/basic-usage/array-arithmetic.rst
@@ -132,7 +132,7 @@ Expand any section for more details.
         z = np.sqrt(x); z
         z ** 2 == x
 
-    See also :func:`~galois.FieldArray.is_square`, :func:`~galois.FieldArray.squares`, and :func:`~galois.FieldArray.quadratic_non_residues`.
+    See also :func:`~galois.FieldArray.is_square`, :func:`~galois.FieldArray.squares`, and :func:`~galois.FieldArray.non_squares`.
 
 .. details:: Logarithm: `np.log(x)` or `x.log()`
 

--- a/docs/basic-usage/array-arithmetic.rst
+++ b/docs/basic-usage/array-arithmetic.rst
@@ -128,10 +128,11 @@ Expand any section for more details.
 
     .. ipython:: python
 
-        # Ensure the elements of x have square roots
-        x.is_quadratic_residue()
+        x.is_square()
         z = np.sqrt(x); z
         z ** 2 == x
+
+    See also :func:`~galois.FieldArray.is_square`, :func:`~galois.FieldArray.quadratic_residues`, and :func:`~galois.FieldArray.quadratic_non_residues`.
 
 .. details:: Logarithm: `np.log(x)` or `x.log()`
 

--- a/docs/basic-usage/array-arithmetic.rst
+++ b/docs/basic-usage/array-arithmetic.rst
@@ -132,7 +132,7 @@ Expand any section for more details.
         z = np.sqrt(x); z
         z ** 2 == x
 
-    See also :func:`~galois.FieldArray.is_square`, :func:`~galois.FieldArray.quadratic_residues`, and :func:`~galois.FieldArray.quadratic_non_residues`.
+    See also :func:`~galois.FieldArray.is_square`, :func:`~galois.FieldArray.squares`, and :func:`~galois.FieldArray.quadratic_non_residues`.
 
 .. details:: Logarithm: `np.log(x)` or `x.log()`
 

--- a/docs/basic-usage/array-creation.rst
+++ b/docs/basic-usage/array-creation.rst
@@ -445,8 +445,8 @@ the polynomial field elements.
 Class properties
 ----------------
 
-Certain class properties, such as :obj:`~galois.FieldArray.elements`, :obj:`~galois.FieldArray.units`, :obj:`~galois.FieldArray.primitive_elements`,
-and :obj:`~galois.FieldArray.quadratic_residues`, provide an array of elements with the specified properties.
+Certain class properties, such as :obj:`~galois.FieldArray.elements`, :obj:`~galois.FieldArray.units`, :obj:`~galois.FieldArray.squares`,
+and :obj:`~galois.FieldArray.primitive_elements`, provide an array of elements with the specified properties.
 
 .. tab-set::
 
@@ -458,8 +458,8 @@ and :obj:`~galois.FieldArray.quadratic_residues`, provide an array of elements w
          GF = galois.GF(3**2)
          GF.elements
          GF.units
+         GF.squares
          GF.primitive_elements
-         GF.quadratic_residues
 
    .. tab-item:: Polynomial
       :sync: poly
@@ -469,8 +469,8 @@ and :obj:`~galois.FieldArray.quadratic_residues`, provide an array of elements w
          GF = galois.GF(3**2, display="poly")
          GF.elements
          GF.units
+         GF.squares
          GF.primitive_elements
-         GF.quadratic_residues
 
    .. tab-item:: Power
       :sync: power
@@ -480,8 +480,8 @@ and :obj:`~galois.FieldArray.quadratic_residues`, provide an array of elements w
          GF = galois.GF(3**2, display="power")
          GF.elements
          GF.units
+         GF.squares
          GF.primitive_elements
-         GF.quadratic_residues
          @suppress
          GF.display()
 

--- a/galois/_domains/_calculate.py
+++ b/galois/_domains/_calculate.py
@@ -757,6 +757,9 @@ class sqrt(_lookup.sqrt_ufunc):
         Algorithm 3.34 from https://cacr.uwaterloo.ca/hac/about/chap3.pdf.
         Algorithm 3.36 from https://cacr.uwaterloo.ca/hac/about/chap3.pdf.
         """
+        if not np.all(a.is_square()):
+            raise ArithmeticError(f"Input array has elements that are non-squares in {self.field.name}.\n{a[~a.is_square()]}")
+
         p = self.field.characteristic
 
         if p % 4 == 3:
@@ -776,7 +779,7 @@ class sqrt(_lookup.sqrt_ufunc):
             # Find a quadratic non-residue element `b`
             while True:
                 b = self.field.Random(low=1)
-                if not b.is_quadratic_residue():
+                if not b.is_square():
                     break
 
             # Write p - 1 = 2^s * t

--- a/galois/_domains/_calculate.py
+++ b/galois/_domains/_calculate.py
@@ -776,7 +776,7 @@ class sqrt(_lookup.sqrt_ufunc):
             roots[idxs] = 2*a[idxs] * (4*a[idxs]) ** ((self.field.order - 5)//8)
 
         else:
-            # Find a quadratic non-residue element `b`
+            # Find a non-square element `b`
             while True:
                 b = self.field.Random(low=1)
                 if not b.is_square():

--- a/galois/_domains/_ufunc.py
+++ b/galois/_domains/_ufunc.py
@@ -442,10 +442,6 @@ class sqrt_ufunc(UFunc):
 
     def __call__(self, ufunc, method, inputs, kwargs, meta):  # pylint: disable=unused-argument
         self._verify_method_only_call(ufunc, method)
-        x = inputs[0]
-        b = x.is_quadratic_residue()  # Boolean indicating if the inputs are quadratic residues
-        if not np.all(b):
-            raise ArithmeticError(f"Input array has elements that are quadratic non-residues (do not have a square root). Use `x.is_quadratic_residue()` to determine if elements have square roots in {self.field.name}.\n{x[~b]}")
         return self.implementation(*inputs)
 
     def implementation(self, a: Array) -> Array:

--- a/galois/_fields/_array.py
+++ b/galois/_fields/_array.py
@@ -281,11 +281,11 @@ class FieldArrayMeta(ArrayMeta):
         return cls._primitive_elements.copy()
 
     @property
-    def quadratic_residues(cls) -> FieldArray:
+    def squares(cls) -> FieldArray:
         r"""
-        All quadratic residues in the finite field.
+        All squares in the finite field.
 
-        An element :math:`x` in :math:`\mathrm{GF}(p^m)` is a *quadratic residue* if there exists a :math:`y` such that
+        An element :math:`x` in :math:`\mathrm{GF}(p^m)` is a *square* if there exists a :math:`y` such that
         :math:`y^2 = x` in the field.
 
         See Also
@@ -294,26 +294,30 @@ class FieldArrayMeta(ArrayMeta):
 
         Examples
         --------
-        In fields with characteristic 2, every element is a quadratic residue.
+        In fields with characteristic 2, every element is a square (with two identical square roots).
 
         .. ipython:: python
 
-            GF = galois.GF(2**4)
-            x = GF.quadratic_residues; x
-            r = np.sqrt(x); r
-            np.array_equal(r ** 2, x)
-            np.array_equal((-r) ** 2, x)
+            GF = galois.GF(2**3, display="poly")
+            x = GF.squares; x
+            y1 = np.sqrt(x); y1
+            y2 = -y1; y2
+            np.array_equal(y1 ** 2, x)
+            np.array_equal(y2 ** 2, x)
+            @suppress
+            GF.display()
 
-        In fields with characteristic greater than 2,exactly half of the nonzero elements are quadratic residues
-        (and they have two unique square roots).
+        In fields with characteristic greater than 2, exactly half of the nonzero elements are squares
+        (with two unique square roots).
 
         .. ipython:: python
 
             GF = galois.GF(11)
-            x = GF.quadratic_residues; x
-            r = np.sqrt(x); r
-            np.array_equal(r ** 2, x)
-            np.array_equal((-r) ** 2, x)
+            x = GF.squares; x
+            y1 = np.sqrt(x); y1
+            y2 = -y1; y2
+            np.array_equal(y1 ** 2, x)
+            np.array_equal(y2 ** 2, x)
         """
         x = cls.elements
         is_square = x.is_square()
@@ -1409,7 +1413,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         See Also
         --------
-        quadratic_residues, quadratic_non_residues
+        squares, quadratic_non_residues
 
         Notes
         -----

--- a/galois/_fields/_array.py
+++ b/galois/_fields/_array.py
@@ -290,7 +290,7 @@ class FieldArrayMeta(ArrayMeta):
 
         See Also
         --------
-        is_quadratic_residue
+        is_square
 
         Examples
         --------
@@ -316,8 +316,8 @@ class FieldArrayMeta(ArrayMeta):
             np.array_equal((-r) ** 2, x)
         """
         x = cls.elements
-        is_quadratic_residue = x.is_quadratic_residue()
-        return x[is_quadratic_residue]
+        is_square = x.is_square()
+        return x[is_square]
 
     @property
     def quadratic_non_residues(cls) -> FieldArray:
@@ -329,7 +329,7 @@ class FieldArrayMeta(ArrayMeta):
 
         See Also
         --------
-        is_quadratic_residue
+        is_square
 
         Examples
         --------
@@ -348,8 +348,8 @@ class FieldArrayMeta(ArrayMeta):
             GF.quadratic_non_residues
         """
         x = cls.elements
-        is_quadratic_residue = x.is_quadratic_residue()
-        return x[~is_quadratic_residue]
+        is_square = x.is_square()
+        return x[~is_square]
 
     @property
     def is_prime_field(cls) -> bool:
@@ -1397,15 +1397,15 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         return order
 
-    def is_quadratic_residue(self) -> Union[np.bool_, np.ndarray]:
+    def is_square(self) -> Union[np.bool_, np.ndarray]:
         r"""
-        Determines if the elements of :math:`x` are quadratic residues in the finite field.
+        Determines if the elements of :math:`x` are squares in the finite field.
 
         Returns
         -------
         :
-            A boolean array indicating if each element in :math:`x` is a quadratic residue. The return value is a single boolean if the
-            input array :math:`x` is a scalar.
+            A boolean array indicating if each element in :math:`x` is a square. The return value is a single boolean
+            if the input array :math:`x` is a scalar.
 
         See Also
         --------
@@ -1413,11 +1413,11 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         Notes
         -----
-        An element :math:`x` in :math:`\mathrm{GF}(p^m)` is a *quadratic residue* if there exists a :math:`y` such that
+        An element :math:`x` in :math:`\mathrm{GF}(p^m)` is a *square* if there exists a :math:`y` such that
         :math:`y^2 = x` in the field.
 
-        In fields with characteristic 2, every element is a quadratic residue. In fields with characteristic greater than 2,
-        exactly half of the nonzero elements are quadratic residues (and they have two unique square roots).
+        In fields with characteristic 2, every element is a square (with two identical square roots). In fields with
+        characteristic greater than 2, exactly half of the nonzero elements are squares (with two unique square roots).
 
         References
         ----------
@@ -1431,7 +1431,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
             GF = galois.GF(2**3, display="poly")
             x = GF.elements; x
-            x.is_quadratic_residue()
+            x.is_square()
             @suppress
             GF.display()
 
@@ -1442,13 +1442,13 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
             GF = galois.GF(11)
             x = GF.elements; x
-            x.is_quadratic_residue()
+            x.is_square()
         """
         x = self
         field = type(self)
 
         if field.characteristic == 2:
-            # All elements are quadratic residues if the field's characteristic is 2
+            # All elements are squares if the field's characteristic is 2
             return np.ones(x.shape, dtype=bool) if x.ndim > 0 else np.bool_(True)
         else:
             # Compute the Legendre symbol on each element

--- a/galois/_fields/_array.py
+++ b/galois/_fields/_array.py
@@ -324,11 +324,11 @@ class FieldArrayMeta(ArrayMeta):
         return x[is_square]
 
     @property
-    def quadratic_non_residues(cls) -> FieldArray:
+    def non_squares(cls) -> FieldArray:
         r"""
-        All quadratic non-residues in the Galois field.
+        All non-squares in the Galois field.
 
-        An element :math:`x` in :math:`\mathrm{GF}(p^m)` is a *quadratic non-residue* if there does not exist a :math:`y` such that
+        An element :math:`x` in :math:`\mathrm{GF}(p^m)` is a *non-square* if there does not exist a :math:`y` such that
         :math:`y^2 = x` in the field.
 
         See Also
@@ -337,19 +337,21 @@ class FieldArrayMeta(ArrayMeta):
 
         Examples
         --------
-        In fields with characteristic 2, no elements are quadratic non-residues.
+        In fields with characteristic 2, no elements are non-squares.
 
         .. ipython:: python
 
-            GF = galois.GF(2**4)
-            GF.quadratic_non_residues
+            GF = galois.GF(2**3, display="poly")
+            GF.non_squares
+            @suppress
+            GF.display()
 
-        In fields with characteristic greater than 2, exactly half of the nonzero elements are quadratic non-residues.
+        In fields with characteristic greater than 2, exactly half of the nonzero elements are non-squares.
 
         .. ipython:: python
 
             GF = galois.GF(11)
-            GF.quadratic_non_residues
+            GF.non_squares
         """
         x = cls.elements
         is_square = x.is_square()
@@ -1413,7 +1415,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         See Also
         --------
-        squares, quadratic_non_residues
+        squares, non_squares
 
         Notes
         -----

--- a/galois/typing.py
+++ b/galois/typing.py
@@ -1,5 +1,5 @@
 """
-A subpackage containing type hints for the :obj:`galois` library.
+A public module containing type hints for the :obj:`galois` library.
 """
 from __future__ import annotations
 

--- a/tests/fields/test_squares.py
+++ b/tests/fields/test_squares.py
@@ -1,5 +1,5 @@
 """
-A pytest module to test the quadratic (non-)residues in finite fields.
+A pytest module to test squares and non-squares in finite fields.
 
 Sage:
     F = GF(79)
@@ -46,23 +46,23 @@ import galois
 def test_shapes():
     GF = galois.GF(31)
     x = GF.Random()
-    assert isinstance(x.is_quadratic_residue(), np.bool_)
+    assert isinstance(x.is_square(), np.bool_)
     x = GF.Random((2,))
-    assert x.is_quadratic_residue().shape == x.shape
+    assert x.is_square().shape == x.shape
     x = GF.Random((2,2))
-    assert x.is_quadratic_residue().shape == x.shape
+    assert x.is_square().shape == x.shape
     x = GF.Random((2,2,2))
-    assert x.is_quadratic_residue().shape == x.shape
+    assert x.is_square().shape == x.shape
 
     GF = galois.GF(2**4)
     x = GF.Random()
-    assert isinstance(x.is_quadratic_residue(), np.bool_)
+    assert isinstance(x.is_square(), np.bool_)
     x = GF.Random((2,))
-    assert x.is_quadratic_residue().shape == x.shape
+    assert x.is_square().shape == x.shape
     x = GF.Random((2,2))
-    assert x.is_quadratic_residue().shape == x.shape
+    assert x.is_square().shape == x.shape
     x = GF.Random((2,2,2))
-    assert x.is_quadratic_residue().shape == x.shape
+    assert x.is_square().shape == x.shape
 
 
 def test_binary_field():
@@ -77,7 +77,7 @@ def test_binary_field():
     assert np.array_equal(qnr, [])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True])
     assert isinstance(b, np.ndarray)
 
@@ -94,7 +94,7 @@ def test_prime_field_1():
     assert np.array_equal(qnr, [3, 5, 6])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, True, False, True, False, False])
     assert isinstance(b, np.ndarray)
 
@@ -111,7 +111,7 @@ def test_prime_field_2():
     assert np.array_equal(qnr, [3, 6, 11, 12, 13, 15, 17, 21, 22, 23, 24, 26, 27, 29, 30])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, True, False, True, True, False, True, True, True, True, False, False, False, True, False, True, False, True, True, True, False, False, False, False, True, False, False, True, False, False])
     assert isinstance(b, np.ndarray)
 
@@ -128,7 +128,7 @@ def test_prime_field_3():
     assert np.array_equal(qnr, [3, 6, 7, 12, 14, 15, 17, 24, 27, 28, 29, 30, 33, 34, 35, 37, 39, 41, 43, 47, 48, 53, 54, 56, 57, 58, 59, 60, 61, 63, 66, 68, 69, 70, 71, 74, 75, 77, 78])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, True, False, True, True, False, False, True, True, True, True, False, True, False, False, True, False, True, True, True, True, True, True, False, True, True, False, False, False, False, True, True, False, False, False, True, False, True, False, True, False, True, False, True, True, True, False, False, True, True, True, True, False, False, True, False, False, False, False, False, False, True, False, True, True, False, True, False, False, False, False, True, True, False, False, True, False, False])
     assert isinstance(b, np.ndarray)
 
@@ -145,7 +145,7 @@ def test_binary_extension_field_1():
     assert np.array_equal(qnr, [])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, True, True, True])
     assert isinstance(b, np.ndarray)
 
@@ -162,7 +162,7 @@ def test_binary_extension_field_2():
     assert np.array_equal(qnr, [])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
     assert isinstance(b, np.ndarray)
 
@@ -180,7 +180,7 @@ def test_binary_extension_field_3():
     assert np.array_equal(qnr, [])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
     assert isinstance(b, np.ndarray)
 
@@ -197,7 +197,7 @@ def test_binary_extension_field_4():
     assert np.array_equal(qnr, [])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
     assert isinstance(b, np.ndarray)
 
@@ -214,7 +214,7 @@ def test_prime_extension_field_1():
     assert np.array_equal(qnr, [3, 5, 6, 7])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, True, False, True, False, False, False, True])
     assert isinstance(b, np.ndarray)
 
@@ -231,7 +231,7 @@ def test_prime_extension_field_2():
     assert np.array_equal(qnr, [2, 3, 4, 5, 10, 14, 17, 18, 19, 21, 23, 24, 26])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, False, False, False, False, True, True, True, True, False, True, True, True, False, True, True, False, False, False, True, False, True, False, False, True, False])
     assert isinstance(b, np.ndarray)
 
@@ -248,6 +248,6 @@ def test_prime_extension_field_3():
     assert np.array_equal(qnr, [5, 7, 9, 10, 13, 14, 15, 16, 17, 20, 21, 23])
     assert type(qnr) is GF
 
-    b = x.is_quadratic_residue()
+    b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, False, True, False, True, False, False, True, True, False, False, False, False, False, True, True, False, False, True, False, True])
     assert isinstance(b, np.ndarray)

--- a/tests/fields/test_squares.py
+++ b/tests/fields/test_squares.py
@@ -4,7 +4,7 @@ A pytest module to test squares and non-squares in finite fields.
 Sage:
     F = GF(79)
     squares = []
-    qnr = []
+    non_squares = []
     b = []
     for x in range(0, F.order()):
         x = F(x)
@@ -13,16 +13,16 @@ Sage:
             squares.append(x)
             b.append(True)
         else:
-            qnr.append(x)
+            non_squares.append(x)
             b.append(False)
     print(squares)
-    print(qnr)
+    print(non_squares)
     print(b)
 
 Sage:
     F = GF(2**3, repr="int")
     squares = []
-    qnr = []
+    non_squares = []
     b = []
     for x in range(0, F.order()):
         x = F.fetch_int(x)
@@ -31,10 +31,10 @@ Sage:
             squares.append(x)
             b.append(True)
         except:
-            qnr.append(x)
+            non_squares.append(x)
             b.append(False)
     print(squares)
-    print(qnr)
+    print(non_squares)
     print(b)
 """
 import pytest
@@ -73,9 +73,9 @@ def test_binary_field():
     assert np.array_equal(squares, [0, 1])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True])
@@ -90,9 +90,9 @@ def test_prime_field_1():
     assert np.array_equal(squares, [0, 1, 2, 4])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [3, 5, 6])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [3, 5, 6])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, True, False, True, False, False])
@@ -107,9 +107,9 @@ def test_prime_field_2():
     assert np.array_equal(squares, [0, 1, 2, 4, 5, 7, 8, 9, 10, 14, 16, 18, 19, 20, 25, 28])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [3, 6, 11, 12, 13, 15, 17, 21, 22, 23, 24, 26, 27, 29, 30])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [3, 6, 11, 12, 13, 15, 17, 21, 22, 23, 24, 26, 27, 29, 30])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, True, False, True, True, False, True, True, True, True, False, False, False, True, False, True, False, True, True, True, False, False, False, False, True, False, False, True, False, False])
@@ -124,9 +124,9 @@ def test_prime_field_3():
     assert np.array_equal(squares, [0, 1, 2, 4, 5, 8, 9, 10, 11, 13, 16, 18, 19, 20, 21, 22, 23, 25, 26, 31, 32, 36, 38, 40, 42, 44, 45, 46, 49, 50, 51, 52, 55, 62, 64, 65, 67, 72, 73, 76])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [3, 6, 7, 12, 14, 15, 17, 24, 27, 28, 29, 30, 33, 34, 35, 37, 39, 41, 43, 47, 48, 53, 54, 56, 57, 58, 59, 60, 61, 63, 66, 68, 69, 70, 71, 74, 75, 77, 78])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [3, 6, 7, 12, 14, 15, 17, 24, 27, 28, 29, 30, 33, 34, 35, 37, 39, 41, 43, 47, 48, 53, 54, 56, 57, 58, 59, 60, 61, 63, 66, 68, 69, 70, 71, 74, 75, 77, 78])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, True, False, True, True, False, False, True, True, True, True, False, True, False, False, True, False, True, True, True, True, True, True, False, True, True, False, False, False, False, True, True, False, False, False, True, False, True, False, True, False, True, False, True, True, True, False, False, True, True, True, True, False, False, True, False, False, False, False, False, False, True, False, True, True, False, True, False, False, False, False, True, True, False, False, True, False, False])
@@ -141,9 +141,9 @@ def test_binary_extension_field_1():
     assert np.array_equal(squares, [0, 1, 2, 3, 4, 5, 6, 7])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, True, True, True])
@@ -158,9 +158,9 @@ def test_binary_extension_field_2():
     assert np.array_equal(squares, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
@@ -176,9 +176,9 @@ def test_binary_extension_field_3():
     assert np.array_equal(squares, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
@@ -193,9 +193,9 @@ def test_binary_extension_field_4():
     assert np.array_equal(squares, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
@@ -210,9 +210,9 @@ def test_prime_extension_field_1():
     assert np.array_equal(squares, [0, 1, 2, 4, 8])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [3, 5, 6, 7])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [3, 5, 6, 7])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, True, False, True, False, False, False, True])
@@ -227,9 +227,9 @@ def test_prime_extension_field_2():
     assert np.array_equal(squares, [0, 1, 6, 7, 8, 9, 11, 12, 13, 15, 16, 20, 22, 25])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [2, 3, 4, 5, 10, 14, 17, 18, 19, 21, 23, 24, 26])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [2, 3, 4, 5, 10, 14, 17, 18, 19, 21, 23, 24, 26])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, False, False, False, False, True, True, True, True, False, True, True, True, False, True, True, False, False, False, True, False, True, False, False, True, False])
@@ -244,9 +244,9 @@ def test_prime_extension_field_3():
     assert np.array_equal(squares, [0, 1, 2, 3, 4, 6, 8, 11, 12, 18, 19, 22, 24])
     assert type(squares) is GF
 
-    qnr = GF.quadratic_non_residues
-    assert np.array_equal(qnr, [5, 7, 9, 10, 13, 14, 15, 16, 17, 20, 21, 23])
-    assert type(qnr) is GF
+    non_squares = GF.non_squares
+    assert np.array_equal(non_squares, [5, 7, 9, 10, 13, 14, 15, 16, 17, 20, 21, 23])
+    assert type(non_squares) is GF
 
     b = x.is_square()
     assert np.array_equal(b, [True, True, True, True, True, False, True, False, True, False, False, True, True, False, False, False, False, False, True, True, False, False, True, False, True])

--- a/tests/fields/test_squares.py
+++ b/tests/fields/test_squares.py
@@ -3,37 +3,37 @@ A pytest module to test squares and non-squares in finite fields.
 
 Sage:
     F = GF(79)
-    qr = []
+    squares = []
     qnr = []
     b = []
     for x in range(0, F.order()):
         x = F(x)
         sqrt_x = sqrt(x)
         if type(sqrt_x) == type(x):
-            qr.append(x)
+            squares.append(x)
             b.append(True)
         else:
             qnr.append(x)
             b.append(False)
-    print(qr)
+    print(squares)
     print(qnr)
     print(b)
 
 Sage:
     F = GF(2**3, repr="int")
-    qr = []
+    squares = []
     qnr = []
     b = []
     for x in range(0, F.order()):
         x = F.fetch_int(x)
         try:
             sqrt_x = sqrt(x)
-            qr.append(x)
+            squares.append(x)
             b.append(True)
         except:
             qnr.append(x)
             b.append(False)
-    print(qr)
+    print(squares)
     print(qnr)
     print(b)
 """
@@ -69,9 +69,9 @@ def test_binary_field():
     GF = galois.GF(2)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [])
@@ -86,9 +86,9 @@ def test_prime_field_1():
     GF = galois.GF(7)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 2, 4])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 2, 4])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [3, 5, 6])
@@ -103,9 +103,9 @@ def test_prime_field_2():
     GF = galois.GF(31)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 2, 4, 5, 7, 8, 9, 10, 14, 16, 18, 19, 20, 25, 28])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 2, 4, 5, 7, 8, 9, 10, 14, 16, 18, 19, 20, 25, 28])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [3, 6, 11, 12, 13, 15, 17, 21, 22, 23, 24, 26, 27, 29, 30])
@@ -120,9 +120,9 @@ def test_prime_field_3():
     GF = galois.GF(79)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 2, 4, 5, 8, 9, 10, 11, 13, 16, 18, 19, 20, 21, 22, 23, 25, 26, 31, 32, 36, 38, 40, 42, 44, 45, 46, 49, 50, 51, 52, 55, 62, 64, 65, 67, 72, 73, 76])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 2, 4, 5, 8, 9, 10, 11, 13, 16, 18, 19, 20, 21, 22, 23, 25, 26, 31, 32, 36, 38, 40, 42, 44, 45, 46, 49, 50, 51, 52, 55, 62, 64, 65, 67, 72, 73, 76])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [3, 6, 7, 12, 14, 15, 17, 24, 27, 28, 29, 30, 33, 34, 35, 37, 39, 41, 43, 47, 48, 53, 54, 56, 57, 58, 59, 60, 61, 63, 66, 68, 69, 70, 71, 74, 75, 77, 78])
@@ -137,9 +137,9 @@ def test_binary_extension_field_1():
     GF = galois.GF(2**3)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 2, 3, 4, 5, 6, 7])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 2, 3, 4, 5, 6, 7])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [])
@@ -154,9 +154,9 @@ def test_binary_extension_field_2():
     GF = galois.GF(2**4)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [])
@@ -172,9 +172,9 @@ def test_binary_extension_field_3():
     GF = galois.GF(2**4, irreducible_poly="x^4 + x^3 + x^2 + x + 1")
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [])
@@ -189,9 +189,9 @@ def test_binary_extension_field_4():
     GF = galois.GF(2**5)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [])
@@ -206,9 +206,9 @@ def test_prime_extension_field_1():
     GF = galois.GF(3**2)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 2, 4, 8])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 2, 4, 8])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [3, 5, 6, 7])
@@ -223,9 +223,9 @@ def test_prime_extension_field_2():
     GF = galois.GF(3**3)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 6, 7, 8, 9, 11, 12, 13, 15, 16, 20, 22, 25])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 6, 7, 8, 9, 11, 12, 13, 15, 16, 20, 22, 25])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [2, 3, 4, 5, 10, 14, 17, 18, 19, 21, 23, 24, 26])
@@ -240,9 +240,9 @@ def test_prime_extension_field_3():
     GF = galois.GF(5**2)
     x = GF.elements
 
-    qr = GF.quadratic_residues
-    assert np.array_equal(qr, [0, 1, 2, 3, 4, 6, 8, 11, 12, 18, 19, 22, 24])
-    assert type(qr) is GF
+    squares = GF.squares
+    assert np.array_equal(squares, [0, 1, 2, 3, 4, 6, 8, 11, 12, 18, 19, 22, 24])
+    assert type(squares) is GF
 
     qnr = GF.quadratic_non_residues
     assert np.array_equal(qnr, [5, 7, 9, 10, 13, 14, 15, 16, 17, 20, 21, 23])


### PR DESCRIPTION
```python
In [1]: import galois

In [2]: GF = galois.GF(13)

In [3]: GF.squares
Out[3]: GF([ 0,  1,  3,  4,  9, 10, 12], order=13)

In [4]: GF.non_squares
Out[4]: GF([ 2,  5,  6,  7,  8, 11], order=13)

In [5]: import numpy as np

In [6]: np.sqrt(GF.squares)
Out[6]: GF([0, 1, 4, 2, 3, 6, 5], order=13)
```