### PR TITLE
Support numpy 1.23

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ include_package_data = true
 test_suite = tests
 python_requires = >=3.7
 install_requires =
-    numpy >= 1.18.4, < 1.23  # v1.18.4 is needed for the new random
+    numpy >= 1.18.4, < 1.24  # v1.18.4 is needed for the new random
     numba >= 0.53, < 0.57  # v0.53 needed for function signautres of CPUDispatchers
     typing_extensions  # Needed for use of Literal in type hints for Python 3.7
 


### PR DESCRIPTION
Numpy 1.23.0 has released. I have updated the version constraint, so I can package it in Nix
https://numpy.org/doc/stable/release/1.23.0-notes.html