### PR TITLE
Fix packaging of direct dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   # push:
   #   branches:
   #     - master
+  workflow_call:
   pull_request:
     branches:
       - master

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,8 +23,11 @@ jobs:
       - name: Upgrade pip
         run: python3 -m pip install --upgrade pip
 
-      - name: Install the `galois` package with [doc]
-        run: python3 -m pip install .[doc]
+      - name: Install the documentation dependencies
+        run: python3 -m pip install -r docs/requirements.txt
+
+      - name: Install the `galois` package
+        run: python3 -m pip install .
 
       - name: Run Sphinx to build docs
         run: sphinx-build -b dirhtml -v docs/ docs/build/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
     tags:
       - v*
 
@@ -17,6 +15,7 @@ jobs:
 
   release:
     name: Create GitHub release
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -53,7 +52,8 @@ jobs:
 
   publish:
     name: Publish on PyPI
-    needs: build, release
+    needs: [build, release]
+    runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,5 +20,6 @@ formats:
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
+    - requirements: docs/requirements.txt
     - method: pip
-      path: .[doc]
+      path: .

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Import the `galois` package in Python.
 In [1]: import galois
 
 In [2]: galois.__version__
-Out[2]: '0.0.32'
+Out[2]: '0.0.33'
 ```
 
 ### Create a [`FieldArray`](https://galois.readthedocs.io/en/latest/api/galois.FieldArray/) subclass

--- a/docs/development/documentation.rst
+++ b/docs/development/documentation.rst
@@ -7,19 +7,17 @@ The :obj:`galois` documentation is generated with `Sphinx <https://www.sphinx-do
 Install
 -------
 
-The documentation dependencies are stored in `pyproject.toml`.
+The documentation dependencies are stored in `docs/requirements.txt`.
 
-.. literalinclude:: ../../pyproject.toml
-   :caption: pyproject.toml
-   :start-at: [project.optional-dependencies]
-   :end-before: [project.urls]
-   :language: toml
+.. literalinclude:: ../requirements.txt
+   :caption: docs/requirements.txt
+   :language: txt
 
-Install the documentation dependencies by passing the `[doc]` extras to `pip install`.
+Install the documentation dependencies by passing the `-r` switch to `pip install`.
 
 .. code-block:: sh
 
-   $ python3 -m pip install .[doc]
+   $ python3 -m pip install -r docs/requirements.txt
 
 Build the docs
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -140,6 +140,7 @@ If this library was useful to you in your research, please cite us. Following th
    :hidden:
 
    release-notes/versioning.rst
+   release-notes/v0.0.33.md
    release-notes/v0.0.32.md
    release-notes/v0.0.31.md
    release-notes/v0.0.30.md

--- a/docs/release-notes/v0.0.33.md
+++ b/docs/release-notes/v0.0.33.md
@@ -1,0 +1,17 @@
+# v0.0.33
+
+*Released August 26, 2022*
+
+## Breaking changes
+
+- Modified FEC `encode()`, `detect()`, and `decode()` methods to always return `FieldArray` instances, not `np.ndarray`. ([#397](https://github.com/mhostetter/galois/pull/397))
+  - Invoke `.view(np.ndarray)` on the output to convert it back to a NumPy array, if needed.
+
+## Changes
+
+- Added support for `ArrayLike` inputs to FEC `encode()`, `detect()`, and `decode()` methods. ([#397](https://github.com/mhostetter/galois/pull/397))
+- Modified library packaging to use `pyproject.toml` and a `src/` source code folder. ([#404](https://github.com/mhostetter/galois/pull/404))
+
+## Contributors
+
+- Matt Hostetter ([@mhostetter](https://github.com/mhostetter))

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+sphinx==5
+git+https://github.com/jbms/sphinx-immaterial@bf169751fba59362bcd06da96bfa65b2728cbbae
+myst-parser
+sphinx-design
+sphinxcontrib-details-directive
+ipykernel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,14 +53,6 @@ dev = [
     "pytest-cov[toml]",
     "pytest-benchmark",
 ]
-doc = [
-    "sphinx==5",
-    "sphinx-immaterial @ git+https://github.com/jbms/sphinx-immaterial@bf169751fba59362bcd06da96bfa65b2728cbbae",
-    "myst-parser",
-    "sphinx-design",
-    "sphinxcontrib-details-directive",
-    "ipykernel",
-]
 
 [project.urls]
 homepage = "https://github.com/mhostetter/galois"


### PR DESCRIPTION
Fix package structure from last attempted TestPyPI upload.

```
Run pypa/gh-action-pypi-publish@v1.4.2
/usr/bin/docker run --name da4232d721ca440f8ab4e6b2f53633fd_b51a0f --label 229416 --workdir /github/workspace --rm -e "INPUT_USER" -e "INPUT_PASSWORD" -e "INPUT_REPOSITORY_URL" -e "INPUT_PACKAGES_DIR" -e "INPUT_VERBOSE" -e "INPUT_VERIFY_METADATA" -e "INPUT_SKIP_EXISTING" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/galois/galois":"/github/workspace" 229416:da4232d721ca440f8ab4e6b2f53633fd  "__token__" "***" "https://test.pypi.org/legacy/" "dist/" "true" "false" "true"
Checking dist/galois-0.0.33-py3-none-any.whl: PASSED
Checking dist/galois-0.0.33.tar.gz: PASSED
Uploading distributions to https://test.pypi.org/legacy/
INFO     dist/galois-0.0.33-py3-none-any.whl (789.7 KB)                         
INFO     dist/galois-0.0.33.tar.gz (3.7 MB)                                     
INFO     username set by command options                                        
INFO     password set by command options                                        
INFO     username: __token__                                                    
INFO     password: <hidden>                                                     
Uploading galois-0.0.33-py3-none-any.whl
25l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/829.9 kB • --:-- • ?
[10](https://github.com/mhostetter/galois/runs/8044699456?check_suite_focus=true#step:4:11)0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 829.9/829.9 kB • 00:00 • 24.6 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 829.9/829.9 kB • 00:00 • 24.6 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 829.9/829.9 kB • 00:00 • 24.6 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 829.9/829.9 kB • 00:00 • 24.6 MB/s
25hINFO     Response from https://test.pypi.org/legacy/:                           
         400 Invalid value for requires_dist. Error: Can't have direct          
         dependency: "sphinx-immaterial @                                       
         git+https://github.com/jbms/sphinx-immaterial@bf169751fba59362bcd06da96
         bfa65b2728cbbae ; extra == 'doc'"                                      
INFO     <html>                                                                 
          <head>                                                                
           <title>400 Invalid value for requires_dist. Error: Can't have direct 
         dependency: "sphinx-immaterial @                                       
         git+https://github.com/jbms/sphinx-immaterial@bf169751fba59362bcd06da96
         bfa65b2728cbbae ; extra == 'doc'"</title>                              
          </head>                                                               
          <body>                                                                
           <h1>400 Invalid value for requires_dist. Error: Can't have direct    
         dependency: "sphinx-immaterial @                                       
         git+https://github.com/jbms/sphinx-immaterial@bf169751fba59362bcd06da96
         bfa65b2728cbbae ; extra == 'doc'"</h1>                                 
           The server could not comply with the request since it is either      
         malformed or otherwise incorrect.<br/><br/>                            
         Invalid value for requires_dist. Error: Can&#x27;t have direct         
         dependency: &quot;sphinx-immaterial @                                  
         git+https://github.com/jbms/sphinx-immaterial@bf169751fba59362bcd06da96
         bfa65b2728cbbae ; extra == &#x27;doc&#x27;&quot;                       
                                                                                
                                                                                
          </body>                                                               
         </html>                                                                
ERROR    HTTPError: 400 Bad Request from https://test.pypi.org/legacy/          
         Invalid value for requires_dist. Error: Can't have direct dependency:  
         "sphinx-immaterial @                                                   
         git+https://github.com/jbms/sphinx-immaterial@bf[16](https://github.com/mhostetter/galois/runs/8044699456?check_suite_focus=true#step:4:17)9751fba59362bcd06da96
         bfa65b[27](https://github.com/mhostetter/galois/runs/8044699456?check_suite_focus=true#step:4:28)[28](https://github.com/mhostetter/galois/runs/8044699456?check_suite_focus=true#step:4:29)cbbae ; extra == 'doc'"
```