### PR TITLE
Add `ipython-with-reprs` Sphinx directive

### DIFF
--- a/docs/basic-usage/array-arithmetic.rst
+++ b/docs/basic-usage/array-arithmetic.rst
@@ -12,8 +12,8 @@ In the sections below, the finite field :math:`\mathrm{GF}(3^5)` and arrays :mat
     x = GF([184, 25, 157, 31]); x
     y = GF([179, 9, 139, 27]); y
 
-Ufuncs
-------
+Standard arithmetic
+-------------------
 
 `NumPy ufuncs <https://numpy.org/devdocs/reference/ufuncs.html>`_ are universal functions that operate on scalars. Unary ufuncs operate on
 a single scalar and binary ufuncs operate on two scalars. NumPy extends the scalar operation of ufuncs to operate on arrays in various ways.
@@ -23,51 +23,59 @@ Expand any section for more details.
 
 .. details:: Addition: `x + y == np.add(x, y)`
     :class: example
-    :open:
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
+        y
         x + y
         np.add(x, y)
 
 .. details:: Additive inverse: `-x == np.negative(x)`
     :class: example
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
         -x
         np.negative(x)
 
     Any array added to its additive inverse results in zero.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
         x + np.negative(x)
 
 .. details:: Subtraction: `x - y == np.subtract(x, y)`
     :class: example
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
+        y
         x - y
         np.subtract(x, y)
 
 .. details:: Multiplication: `x * y == np.multiply(x, y)`
     :class: example
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
+        y
         x * y
         np.multiply(x, y)
 
-.. details:: Scalar multiplication: `x * z == np.multiply(x, z)`
+.. details:: Scalar multiplication: `x * 4 == np.multiply(x, 4)`
     :class: example
 
     Scalar multiplication is essentially *repeated addition*. It is the "multiplication" of finite field elements
     and integers. The integer value indicates how many additions of the field element to sum.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
         x * 4
         np.multiply(x, 4)
         x + x + x + x
@@ -75,7 +83,7 @@ Expand any section for more details.
     In finite fields :math:`\mathrm{GF}(p^m)`, the characteristic :math:`p` is the smallest value when multiplied by
     any non-zero field element that results in 0.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         p = GF.characteristic; p
         x * p
@@ -83,23 +91,26 @@ Expand any section for more details.
 .. details:: Multiplicative inverse: `y ** -1 == np.reciprocal(y)`
     :class: example
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        y
         y ** -1
         GF(1) / y
         np.reciprocal(y)
 
     Any array multiplied by its multiplicative inverse results in one.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         y * np.reciprocal(y)
 
 .. details:: Division: `x / y == x // y == np.divide(x, y)`
     :class: example
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
+        y
         x / y
         x // y
         np.divide(x, y)
@@ -107,30 +118,35 @@ Expand any section for more details.
 .. details:: Remainder: `x % y == np.remainder(x, y)`
     :class: example
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
+        y
         x % y
         np.remainder(x, y)
 
 .. details:: Divmod: `divmod(x, y) == np.divmod(x, y)`
     :class: example
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
+        y
         x // y, x % y
         divmod(x, y)
         np.divmod(x, y)
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         q, r = divmod(x, y)
         q*y + r == x
 
-.. details:: Exponentiation: `x ** z == np.power(x, z)`
+.. details:: Exponentiation: `x ** 3 == np.power(x, 3)`
     :class: example
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
         x ** 3
         np.power(x, 3)
         x * x * x
@@ -138,8 +154,9 @@ Expand any section for more details.
 .. details:: Square root: `np.sqrt(x)`
     :class: example
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
         x.is_square()
         z = np.sqrt(x); z
         z ** 2 == x
@@ -151,8 +168,9 @@ Expand any section for more details.
 
     Compute the logarithm base :math:`\alpha`, the primitive element of the field.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        y
         z = np.log(y); z
         alpha = GF.primitive_element; alpha
         alpha ** z == y
@@ -160,8 +178,9 @@ Expand any section for more details.
     Compute the logarithm base :math:`\beta`, a different primitive element of the field. See :func:`FieldArray.log` for more
     details.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        y
         beta = GF.primitive_elements[-1]; beta
         z = y.log(beta); z
         beta ** z == y
@@ -176,16 +195,16 @@ Expand any section for more details.
 
 .. details:: `reduce()`
     :class: example
-    :open:
 
     The :obj:`~numpy.ufunc.reduce` methods reduce the input array's dimension by one, applying the ufunc across one axis.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
         np.add.reduce(x)
         x[0] + x[1] + x[2] + x[3]
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         np.multiply.reduce(x)
         x[0] * x[1] * x[2] * x[3]
@@ -195,12 +214,13 @@ Expand any section for more details.
 
     The :obj:`~numpy.ufunc.accumulate` methods accumulate the result of the ufunc across a specified axis.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
         np.add.accumulate(x)
         GF([x[0], x[0] + x[1], x[0] + x[1] + x[2], x[0] + x[1] + x[2] + x[3]])
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         np.multiply.accumulate(x)
         GF([x[0], x[0] * x[1], x[0] * x[1] * x[2], x[0] * x[1] * x[2] * x[3]])
@@ -211,12 +231,13 @@ Expand any section for more details.
     The :obj:`~numpy.ufunc.reduceat` methods reduces the input array's dimension by one, applying the ufunc across one axis
     in-between certain indices.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
         np.add.reduceat(x, [0, 3])
         GF([x[0] + x[1] + x[2], x[3]])
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         np.multiply.reduceat(x, [0, 3])
         GF([x[0] * x[1] * x[2], x[3]])
@@ -226,11 +247,13 @@ Expand any section for more details.
 
     The :obj:`~numpy.ufunc.outer` methods applies the ufunc to each pair of inputs.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
+        y
         np.add.outer(x, y)
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         np.multiply.outer(x, y)
 
@@ -239,8 +262,9 @@ Expand any section for more details.
 
     The :obj:`~numpy.ufunc.at` methods performs the ufunc in-place at the specified indices.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
         z = x.copy()
         # Negate indices 0 and 1 in-place
         np.negative.at(x, [0, 1]); x
@@ -253,10 +277,11 @@ Advanced arithmetic
 
 .. details:: Convolution: `np.convolve(x, y)`
     :class: example
-    :open:
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
+        x
+        y
         np.convolve(x, y)
 
 .. details:: FFT: `np.fft.fft(x)`
@@ -265,13 +290,13 @@ Advanced arithmetic
     The Discrete Fourier Transform (DFT) of size :math:`n` over the finite field :math:`\mathrm{GF}(p^m)` exists when there
     exists a primitive :math:`n`-th root of unity. This occurs when :math:`n\ |\ p^m - 1`.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         GF = galois.GF(7**5)
         n = 6
         # n divides p^m - 1
         (GF.order - 1) % n
-        x = GF.Random(n); x
+        x = GF.Random(n, seed=1); x
         X = np.fft.fft(x); X
         np.fft.ifft(X)
 
@@ -283,13 +308,13 @@ Advanced arithmetic
     The inverse Discrete Fourier Transform (DFT) of size :math:`n` over the finite field :math:`\mathrm{GF}(p^m)` exists when there
     exists a primitive :math:`n`-th root of unity. This occurs when :math:`n\ |\ p^m - 1`.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         GF = galois.GF(7**5)
         n = 6
         # n divides p^m - 1
         (GF.order - 1) % n
-        x = GF.Random(n); x
+        x = GF.Random(n, seed=1); x
         X = np.fft.fft(x); X
         np.fft.ifft(X)
 
@@ -305,7 +330,6 @@ Expand any section for more details.
 
 .. details:: Dot product: `np.dot(a, b)`
     :class: example
-    :open:
 
     .. ipython:: python
 
@@ -355,7 +379,7 @@ Expand any section for more details.
         A @ B
         np.matmul(A, B)
 
-.. details:: Matrix exponentiation: `np.linalg.matrix_power(A, z)`
+.. details:: Matrix exponentiation: `np.linalg.matrix_power(A, 3)`
     :class: example
 
     .. ipython:: python
@@ -374,7 +398,7 @@ Expand any section for more details.
         A = GF([[23, 11, 3, 3], [13, 6, 16, 4], [12, 10, 5, 3], [17, 23, 15, 28]]); A
         np.linalg.det(A)
 
-.. details:: Matrix rank: `np.linalg.matrix_rank(A, z)`
+.. details:: Matrix rank: `np.linalg.matrix_rank(A)`
     :class: example
 
     .. ipython:: python
@@ -423,7 +447,6 @@ not included in NumPy.
 
 .. details:: Row space: `A.row_space()`
     :class: example
-    :open:
 
     .. ipython:: python
 

--- a/docs/basic-usage/array-classes.rst
+++ b/docs/basic-usage/array-classes.rst
@@ -16,7 +16,7 @@ and :func:`~galois.GR` (future).
 
 A :obj:`~galois.FieldArray` subclass is created using the class factory function :func:`~galois.GF`.
 
-.. ipython:: python
+.. ipython-with-reprs:: int,poly,power
 
     GF = galois.GF(3**5)
     print(GF.properties)
@@ -66,7 +66,7 @@ with :obj:`~galois.FieldArray.irreducible_poly`.
 
 A :obj:`~galois.FieldArray` instance is created using `GF`'s constructor.
 
-.. ipython:: python
+.. ipython-with-reprs:: int,poly,power
 
     x = GF([23, 78, 163, 124])
     x
@@ -94,13 +94,13 @@ alternate constructors use `PascalCase` while other classmethods use `snake_case
 
 For example, to generate a random array of given shape call :func:`~galois.FieldArray.Random`.
 
-.. ipython:: python
+.. ipython-with-reprs:: int,poly,power
 
-    GF.Random((2, 3))
+    GF.Random((3, 2), seed=1)
 
 Or, create an identity matrix using :func:`~galois.FieldArray.Identity`.
 
-.. ipython:: python
+.. ipython-with-reprs:: int,poly,power
 
     GF.Identity(4)
 

--- a/docs/basic-usage/array-creation.rst
+++ b/docs/basic-usage/array-creation.rst
@@ -100,11 +100,11 @@ useful for initializing empty arrays.
    GF.Zeros(4)
    GF.Ones(4)
 
-.. note::
+.. details:: There is no :func:`numpy.empty` equivalent.
+   :class: note
 
-   There is no :func:`numpy.empty` equivalent. This is because :obj:`~galois.FieldArray` instances must have values in
-   :math:`[0, p^m)`. Empty NumPy arrays have whatever values are currently in memory, and therefore would fail those
-   bounds checks.
+   This is because :obj:`~galois.FieldArray` instances must have values in :math:`[0, p^m)`. Empty NumPy arrays have whatever values
+   are currently in memory, and therefore would fail those bounds checks during instantiation.
 
 Ordered arrays
 ..............
@@ -126,8 +126,8 @@ the polynomial field elements.
 
 .. ipython-with-reprs:: int,poly,power
 
-   GF.Random(4, seed=1234)
-   GF.Random(4, low=10, high=20, seed=5678)
+   GF.Random(4, seed=1)
+   GF.Random(4, low=10, high=20, seed=2)
 
 Class properties
 ----------------

--- a/docs/basic-usage/array-creation.rst
+++ b/docs/basic-usage/array-creation.rst
@@ -4,28 +4,10 @@ Array Creation
 This page discusses the multiple ways to create arrays over finite fields. For this discussion, we are working in
 the finite field :math:`\mathrm{GF}(3^5)`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         GF = galois.GF(3**5)
-         print(GF.properties)
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         GF = galois.GF(3**5, display="poly")
-         print(GF.properties)
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         GF = galois.GF(3**5, display="power")
-         print(GF.properties)
+   GF = galois.GF(3**5)
+   print(GF.properties)
 
 Create a scalar
 ---------------
@@ -33,37 +15,11 @@ Create a scalar
 A single finite field element (a scalar) is a 0-D :obj:`~galois.FieldArray`. They are created by passing a single
 :obj:`~galois.typing.ElementLike` object to `GF`'s constructor.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         a = GF(17); a
-         a = GF("x^2 + 2x + 2"); a
-         a.ndim
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         a = GF(17); a
-         a = GF("x^2 + 2x + 2"); a
-         a.ndim
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         a = GF(17); a
-         a = GF("x^2 + 2x + 2"); a
-         a.ndim
+   a = GF(17); a
+   a = GF("x^2 + 2x + 2"); a
+   a.ndim
 
 Create a new array
 ------------------
@@ -73,34 +29,10 @@ Array-Like objects
 
 A :obj:`~galois.FieldArray` can be created from various :obj:`~galois.typing.ArrayLike` objects.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         GF([17, 4, 148, 205])
-         GF([["x^2 + 2x + 2", 4], ["x^4 + 2x^3 + x^2 + x + 1", 205]])
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         GF([17, 4, 148, 205])
-         GF([["x^2 + 2x + 2", 4], ["x^4 + 2x^3 + x^2 + x + 1", 205]])
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         GF([17, 4, 148, 205])
-         GF([["x^2 + 2x + 2", 4], ["x^4 + 2x^3 + x^2 + x + 1", 205]])
+   GF([17, 4, 148, 205])
+   GF([["x^2 + 2x + 2", 4], ["x^4 + 2x^3 + x^2 + x + 1", 205]])
 
 Polynomial coefficients
 .......................
@@ -108,97 +40,27 @@ Polynomial coefficients
 Rather than strings, the polynomial coefficients may be passed into `GF`'s constructor as length-:math:`m` vectors using
 the :func:`~galois.FieldArray.Vector` classmethod.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         GF.Vector([[0, 0, 1, 2, 2], [0, 0, 0, 1, 1]])
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         GF.Vector([[0, 0, 1, 2, 2], [0, 0, 0, 1, 1]])
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         GF.Vector([[0, 0, 1, 2, 2], [0, 0, 0, 1, 1]])
+   GF.Vector([[0, 0, 1, 2, 2], [0, 0, 0, 1, 1]])
 
 The :func:`~galois.FieldArray.vector` method is the opposite operation. It converts extension field elements from :math:`\mathrm{GF}(p^m)`
 into length-:math:`m` vectors over :math:`\mathrm{GF}(p)`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         GF([17, 4]).vector()
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         GF([17, 4]).vector()
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         GF([17, 4]).vector()
+   GF([17, 4]).vector()
 
 Primitive element powers
 ........................
 
 A :obj:`~galois.FieldArray` can also be created from the powers of a primitive element :math:`\alpha`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         alpha = GF.primitive_element; alpha
-         powers = np.array([222, 69, 54, 24]); powers
-         alpha ** powers
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         alpha = GF.primitive_element; alpha
-         powers = np.array([222, 69, 54, 24]); powers
-         alpha ** powers
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         alpha = GF.primitive_element; alpha
-         powers = np.array([222, 69, 54, 24]); powers
-         alpha ** powers
+   alpha = GF.primitive_element; alpha
+   powers = np.array([222, 69, 54, 24]); powers
+   alpha ** powers
 
 NumPy array
 ...........
@@ -206,40 +68,12 @@ NumPy array
 An integer NumPy array may also be passed into `GF`. The default keyword argument `copy=True` of the :obj:`~galois.FieldArray`
 constructor will create a copy of the array.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         x_np = np.array([213, 167, 4, 214, 209]); x_np
-         x = GF(x_np); x
-         # Modifying x does not modify x_np
-         x[0] = 0; x_np
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         x_np = np.array([213, 167, 4, 214, 209]); x_np
-         x = GF(x_np); x
-         # Modifying x does not modify x_np
-         x[0] = 0; x_np
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         x_np = np.array([213, 167, 4, 214, 209]); x_np
-         x = GF(x_np); x
-         # Modifying x does not modify x_np
-         x[0] = 0; x_np
+   x_np = np.array([213, 167, 4, 214, 209]); x_np
+   x = GF(x_np); x
+   # Modifying x does not modify x_np
+   x[0] = 0; x_np
 
 View an existing array
 ----------------------
@@ -250,40 +84,12 @@ temporarily and work with it in-place.
 Simply call `.view(GF)` to *view* the NumPy array as a :obj:`~galois.FieldArray`. When finished working in the
 finite field, call `.view(np.ndarray)` to *view* it back to a NumPy array.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         x_np = np.array([213, 167, 4, 214, 209], dtype=int); x_np
-         x = x_np.view(GF); x
-         # Modifying x does modify x_np!
-         x[0] = 0; x_np
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         x_np = np.array([213, 167, 4, 214, 209], dtype=int); x_np
-         x = x_np.view(GF); x
-         # Modifying x does modify x_np!
-         x[0] = 0; x_np
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         x_np = np.array([213, 167, 4, 214, 209], dtype=int); x_np
-         x = x_np.view(GF); x
-         # Modifying x does modify x_np!
-         x[0] = 0; x_np
+   x_np = np.array([213, 167, 4, 214, 209], dtype=int); x_np
+   x = x_np.view(GF); x
+   # Modifying x does modify x_np!
+   x[0] = 0; x_np
 
 Classmethods
 ------------
@@ -296,34 +102,10 @@ Constant arrays
 The :func:`~galois.FieldArray.Zeros` and :func:`~galois.FieldArray.Ones` classmethods provide constant arrays that are
 useful for initializing empty arrays.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         GF.Zeros(4)
-         GF.Ones(4)
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         GF.Zeros(4)
-         GF.Ones(4)
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         GF.Zeros(4)
-         GF.Ones(4)
+   GF.Zeros(4)
+   GF.Ones(4)
 
 .. note::
 
@@ -337,34 +119,10 @@ Ordered arrays
 The :func:`~galois.FieldArray.Range` classmethod produces a range of elements similar to :func:`numpy.arange`. The integer `start`
 and `stop` values are the :ref:`integer representation <int-repr>` of the polynomial field elements.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         GF.Range(10, 20)
-         GF.Range(10, 20, 2)
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         GF.Range(10, 20)
-         GF.Range(10, 20, 2)
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         GF.Range(10, 20)
-         GF.Range(10, 20, 2)
+   GF.Range(10, 20)
+   GF.Range(10, 20, 2)
 
 Random arrays
 .............
@@ -373,41 +131,10 @@ The :func:`~galois.FieldArray.Random` classmethod provides a random array of the
 for testing. The integer `low` and `high` values are the :ref:`integer representation <int-repr>` of
 the polynomial field elements.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("int")
-         GF.Random(4, seed=1234)
-         GF.Random(4, low=10, high=20, seed=5678)
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("poly")
-         GF.Random(4, seed=1234)
-         GF.Random(4, low=10, high=20, seed=5678)
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF.display("power")
-         GF.Random(4, seed=1234)
-         GF.Random(4, low=10, high=20, seed=5678)
-
-..
-   Reset the display mode to the integer representation so other pages aren't affected
-.. ipython:: python
-   :suppress:
-
-   GF.display("int")
+   GF.Random(4, seed=1234)
+   GF.Random(4, low=10, high=20, seed=5678)
 
 Class properties
 ----------------
@@ -415,39 +142,13 @@ Class properties
 Certain class properties, such as :obj:`~galois.FieldArray.elements`, :obj:`~galois.FieldArray.units`, :obj:`~galois.FieldArray.squares`,
 and :obj:`~galois.FieldArray.primitive_elements`, provide an array of elements with the specified properties.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         GF = galois.GF(3**2)
-         GF.elements
-         GF.units
-         GF.squares
-         GF.primitive_elements
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         GF = galois.GF(3**2, display="poly")
-         GF.elements
-         GF.units
-         GF.squares
-         GF.primitive_elements
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         GF = galois.GF(3**2, display="power")
-         GF.elements
-         GF.units
-         GF.squares
-         GF.primitive_elements
-         @suppress
-         GF.display()
+   GF = galois.GF(3**2)
+   GF.elements
+   GF.units
+   GF.squares
+   GF.primitive_elements
 
 Data types
 ----------

--- a/docs/basic-usage/array-creation.rst
+++ b/docs/basic-usage/array-creation.rst
@@ -8,31 +8,35 @@ the finite field :math:`\mathrm{GF}(3^5)`.
 
    GF = galois.GF(3**5)
    print(GF.properties)
+   alpha = GF.primitive_element; alpha
 
 Create a scalar
 ---------------
 
 A single finite field element (a scalar) is a 0-D :obj:`~galois.FieldArray`. They are created by passing a single
-:obj:`~galois.typing.ElementLike` object to `GF`'s constructor.
+:obj:`~galois.typing.ElementLike` object to `GF`'s constructor. A finite field scalar may also be created by exponentiating
+the primitive element to a scalar power.
 
 .. ipython-with-reprs:: int,poly,power
 
-   a = GF(17); a
-   a = GF("x^2 + 2x + 2"); a
-   a.ndim
+   GF(17)
+   GF("x^2 + 2x + 2")
+   alpha ** 222
 
 Create a new array
 ------------------
 
-Array-Like objects
+Array-like objects
 ..................
 
 A :obj:`~galois.FieldArray` can be created from various :obj:`~galois.typing.ArrayLike` objects.
+A finite field array may also be created by exponentiating the primitive element to a an array of powers.
 
 .. ipython-with-reprs:: int,poly,power
 
    GF([17, 4, 148, 205])
    GF([["x^2 + 2x + 2", 4], ["x^4 + 2x^3 + x^2 + x + 1", 205]])
+   alpha ** np.array([[222, 69], [54, 24]])
 
 Polynomial coefficients
 .......................
@@ -50,17 +54,6 @@ into length-:math:`m` vectors over :math:`\mathrm{GF}(p)`.
 .. ipython-with-reprs:: int,poly,power
 
    GF([17, 4]).vector()
-
-Primitive element powers
-........................
-
-A :obj:`~galois.FieldArray` can also be created from the powers of a primitive element :math:`\alpha`.
-
-.. ipython-with-reprs:: int,poly,power
-
-   alpha = GF.primitive_element; alpha
-   powers = np.array([222, 69, 54, 24]); powers
-   alpha ** powers
 
 NumPy array
 ...........

--- a/docs/basic-usage/element-representation.rst
+++ b/docs/basic-usage/element-representation.rst
@@ -80,7 +80,7 @@ coefficient as the most-significant digit and zero-degree coefficient as the lea
 
     GF = galois.GF(3**5)
     GF(17)
-    GF("α^2 + 2α + 2")
+    GF("x^2 + 2x + 2")
     # Integer/polynomial equivalence
     p = 3; p**2 + 2*p + 2 == 17
 
@@ -106,7 +106,7 @@ This is useful, however it can become cluttered for large arrays.
 
     GF = galois.GF(3**5, display="poly")
     GF(17)
-    GF("α^2 + 2α + 2")
+    GF("x^2 + 2x + 2")
     # Integer/polynomial equivalence
     p = 3; p**2 + 2*p + 2 == 17
 
@@ -139,8 +139,8 @@ In prime fields, the elements are displayed as :math:`\{0, 1, \alpha, \alpha^2, 
 .. ipython:: python
 
     GF.display("int");
-    α = GF.primitive_element; α
-    α**23
+    alpha = GF.primitive_element; alpha
+    alpha ** 23
 
 In extension fields, the elements are displayed as :math:`\{0, 1, \alpha, \alpha^2, \dots, \alpha^{p^m-2}\}`.
 
@@ -152,8 +152,8 @@ In extension fields, the elements are displayed as :math:`\{0, 1, \alpha, \alpha
 .. ipython:: python
 
     GF.display("int");
-    α = GF.primitive_element; α
-    α**222
+    alpha = GF.primitive_element; alpha
+    alpha ** 222
 
 Vector representation
 ---------------------
@@ -166,16 +166,16 @@ The vector representation is accessed using the :func:`~galois.FieldArray.vector
 .. ipython:: python
 
     GF = galois.GF(3**5, display="poly")
-    GF("α^2 + 2α + 2")
-    GF("α^2 + 2α + 2").vector()
+    GF("x^2 + 2x + 2")
+    GF("x^2 + 2x + 2").vector()
 
 An N-D array over :math:`\mathrm{GF}(p^m)` is converted to a (N + 1)-D array over :math:`\mathrm{GF}(p)` with the added dimension having
 size :math:`m`. The first value of the vector is the highest-degree coefficient.
 
 .. ipython:: python
 
-    GF(["α^2 + 2α + 2", "2α^4 + α"])
-    GF(["α^2 + 2α + 2", "2α^4 + α"]).vector()
+    GF(["x^2 + 2x + 2", "2x^4 + x"])
+    GF(["x^2 + 2x + 2", "2x^4 + x"]).vector()
 
 Arrays can be created from the vector representation using the :func:`~galois.FieldArray.Vector` classmethod.
 

--- a/docs/basic-usage/poly-arithmetic.rst
+++ b/docs/basic-usage/poly-arithmetic.rst
@@ -1,12 +1,6 @@
 Polynomial Arithmetic
 =====================
 
-Standard arithmetic
--------------------
-
-After creating a :doc:`polynomial over a finite field <poly>`, nearly any polynomial arithmetic operation can be
-performed using Python operators.
-
 In the sections below, the finite field :math:`\mathrm{GF}(7)` and polynomials :math:`f(x)` and :math:`g(x)` are used.
 
 .. ipython:: python
@@ -15,16 +9,21 @@ In the sections below, the finite field :math:`\mathrm{GF}(7)` and polynomials :
     f = galois.Poly([1, 0, 4, 3], field=GF); f
     g = galois.Poly([2, 1, 3], field=GF); g
 
-Expand any section for more details.
+Standard arithmetic
+-------------------
+
+After creating a :doc:`polynomial over a finite field <poly>`, nearly any polynomial arithmetic operation can be
+performed using Python operators. Expand any section for more details.
 
 .. details:: Addition: `f + g`
     :class: example
-    :open:
 
     Add two polynomials.
 
     .. ipython:: python
 
+        f
+        g
         f + g
 
     Add a polynomial and a finite field scalar. The scalar is treated as a 0-degree polynomial.
@@ -39,12 +38,14 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
         -f
 
     Any polynomial added to its additive inverse results in zero.
 
     .. ipython:: python
 
+        f
         f + -f
 
 .. details:: Subtraction: `f - g`
@@ -54,6 +55,8 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
+        g
         f - g
 
     Subtract finite field scalar from a polynomial, or vice versa. The scalar is treated as a 0-degree polynomial.
@@ -70,6 +73,8 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
+        g
         f * g
 
     Multiply a polynomial and a finite field scalar. The scalar is treated as a 0-degree polynomial.
@@ -106,6 +111,8 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
+        g
         f // g
 
     Divide a polynomial by a finite field scalar, or vice versa. The scalar is treated as a 0-degree polynomial.
@@ -122,6 +129,8 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
+        g
         f % g
 
     Divide a polynomial by a finite field scalar, or vice versa, and keep the remainder. The scalar is treated as a 0-degree polynomial.
@@ -138,6 +147,8 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
+        g
         divmod(f, g)
 
     Divide a polynomial by a finite field scalar, or vice versa, and keep the remainder. The scalar is treated as a 0-degree polynomial.
@@ -154,6 +165,7 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
         f ** 3
         pow(f, 3)
         f * f * f
@@ -165,8 +177,15 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
+        g
         # Efficiently computes (f ** 123456789) % g
         pow(f, 123456789, g)
+
+Evaluation
+----------
+
+Polynomial objects may also be evaluated at scalars, arrays, or square matrices. Expand any section for more details.
 
 .. details:: Evaluation (element-wise): `f(x)` or `f(X)`
     :class: example
@@ -175,25 +194,24 @@ Expand any section for more details.
 
     .. ipython:: python
 
-        GF = galois.GF(31)
-        f = galois.Poly([1, 0, 0, 15], field=GF); f
-        f(26)
+        f
+        f(5)
 
         # The equivalent field calculation
-        GF(26)**3 + GF(15)
+        GF(5)**3 + 4*GF(5) + GF(3)
 
     Or they can be evaluated at arrays element-wise.
 
     .. ipython:: python
 
-        x = GF([26, 13, 24, 4])
+        x = GF([5, 6, 3, 4])
 
         # Evaluate f(x) element-wise at a 1-D array
         f(x)
 
     .. ipython:: python
 
-        X = GF([[26, 13], [24, 4]])
+        X = GF([[5, 6], [3, 4]])
 
         # Evaluate f(x) element-wise at a 2-D array
         f(X)
@@ -208,32 +226,23 @@ Expand any section for more details.
     .. ipython:: python
 
         f
-
-        # Evaluate f(x) at the 2-D square matrix
         f(X, elementwise=False)
 
         # The equivalent matrix operation
-        np.linalg.matrix_power(X, 3) + GF(15)*GF.Identity(X.shape[0])
+        np.linalg.matrix_power(X, 3) + 4*X + GF(3)*GF.Identity(X.shape[0])
 
 Special arithmetic
 ------------------
 
-Polynomial objects also work on several special arithmetic operations. Below are some examples.
-
-.. ipython:: python
-
-    GF = galois.GF(31)
-    f = galois.Poly([1, 30, 0, 26, 6], field=GF); f
-    g = galois.Poly([4, 17, 3], field=GF); g
-
-Expand any section for more details.
+Polynomial objects also work on several special arithmetic operations. Expand any section for more details.
 
 .. details:: Greatest common denominator: `galois.gcd(f, g)`
     :class: example
-    :open:
 
     .. ipython:: python
 
+        f
+        g
         d = galois.gcd(f, g); d
         f % d
         g % d
@@ -245,6 +254,8 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
+        g
         d, s, t = galois.egcd(f, g)
         d, s, t
         f*s + g*t == d
@@ -256,6 +267,7 @@ Expand any section for more details.
 
     .. ipython:: python
 
+        f
         galois.factors(f)
         f.factors()
 

--- a/docs/basic-usage/poly-arithmetic.rst
+++ b/docs/basic-usage/poly-arithmetic.rst
@@ -231,6 +231,17 @@ Polynomial objects may also be evaluated at scalars, arrays, or square matrices.
         # The equivalent matrix operation
         np.linalg.matrix_power(X, 3) + 4*X + GF(3)*GF.Identity(X.shape[0])
 
+.. details:: Composition: `f(g)`
+    :class: example
+
+    Polynomial composition :math:`f(g(x))` is easily performed using an overload to :func:`~galois.Poly.__call__`.
+
+    .. ipython:: python
+
+        f
+        g
+        f(g)
+
 Special arithmetic
 ------------------
 

--- a/docs/basic-usage/poly.rst
+++ b/docs/basic-usage/poly.rst
@@ -20,9 +20,15 @@ Or pass a :obj:`~galois.FieldArray` of coefficients without explicitly specifyin
    coeffs = GF([1, 0, 0, 55, 23]); coeffs
    galois.Poly(coeffs)
 
-.. tip::
+.. details:: Use :func:`~galois.set_printoptions` to display the polynomial coefficients in degree-ascending order.
+   :class: tip
 
-   Use :func:`~galois.set_printoptions` to display the polynomial coefficients in degree-ascending order.
+   .. ipython:: python
+
+      galois.set_printoptions(coeffs="asc")
+      galois.Poly(coeffs)
+      @suppress
+      galois.set_printoptions(coeffs="desc")
 
 Element representation
 ----------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 import inspect
 import os
 import sys
+sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath(".."))
 
 # Need to build docs with Python 3.8 or higher for proper typing annotations, including from __future__ import annotations
@@ -53,7 +54,8 @@ extensions = [
     "sphinx_design",
     "sphinxcontrib.details.directive",
     "IPython.sphinxext.ipython_console_highlighting",
-    "IPython.sphinxext.ipython_directive"
+    "IPython.sphinxext.ipython_directive",
+    "ipython_with_reprs",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/ipython_with_reprs.py
+++ b/docs/ipython_with_reprs.py
@@ -1,0 +1,97 @@
+"""
+Sphinx extension that adds `ipython-with-reprs` directive.
+"""
+from typing import List
+
+import docutils.nodes
+import sphinx.addnodes
+import sphinx.application
+import sphinx.util.docutils
+import sphinx.util.logging
+
+logger = sphinx.util.logging.getLogger(__name__)
+
+DISPLAY_MODE_TO_TITLE = {
+    "int": "Integer",
+    "poly": "Polynomial",
+    "power": "Power",
+}
+
+
+class IPythonWithReprsDirective(sphinx.util.docutils.SphinxDirective):
+
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 1
+    option_spec = {
+        "name": str,
+    }
+
+    def run(self) -> List[docutils.nodes.Node]:
+        self.assert_has_content()
+
+        # Parse input parameters
+        display_modes = self.arguments[0].split(",")
+        titles = [DISPLAY_MODE_TO_TITLE[mode] for mode in display_modes]
+        field = self.options.get("name", "GF")
+
+        ws = "    "
+        new_lines = [
+            ".. md-tab-set::",
+            ""
+        ]
+
+        for mode, title in zip(display_modes, titles):
+            new_lines += [
+                f"{ws}.. md-tab-item:: {title}",
+                "",
+                f"{ws}{ws}.. ipython:: python",
+                "",
+            ]
+
+            # Set the Galois field display mode
+            first_code_line = self.content[0]
+            if first_code_line.startswith(f"{field} = "):
+                assert "display=" not in first_code_line
+                if mode == "int":
+                    new_first_code_line = first_code_line
+                else:
+                    items = first_code_line.rsplit(")", 1)
+                    assert len(items) == 2
+                    items.insert(1, f", display=\"{mode}\")")
+                    new_first_code_line = "".join(items)
+                new_lines += [
+                    f"{ws}{ws}{ws}{new_first_code_line}",
+                ]
+            else:
+                new_lines += [
+                    f"{ws}{ws}{ws}@suppress",
+                    f"{ws}{ws}{ws}{field}.display(\"{mode}\")",
+                    f"{ws}{ws}{ws}{first_code_line}",
+                ]
+
+            # Add the raw python code
+            for code_line in self.content[1:]:
+                new_lines += [
+                    f"{ws}{ws}{ws}{code_line}",
+                ]
+
+            # Reset the Galois field display mode
+            new_lines += [
+                f"{ws}{ws}{ws}@suppress",
+                f"{ws}{ws}{ws}{field}.display()",
+                ""
+            ]
+
+        self.state_machine.insert_input(new_lines, self.state_machine.input_lines.source(0))
+
+        return []
+
+
+def setup(app: sphinx.application.Sphinx):
+    app.add_directive("ipython-with-reprs", IPythonWithReprsDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/tutorials/intro-to-extension-fields.rst
+++ b/docs/tutorials/intro-to-extension-fields.rst
@@ -14,28 +14,11 @@ Extension field
 In this tutorial, we will consider the extension field :math:`\mathrm{GF}(3^2)`. Using the :obj:`galois` library, the :obj:`~galois.FieldArray` subclass
 `GF9` is created using the class factory :func:`~galois.GF`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         GF9 = galois.GF(3**2)
-         print(GF9.properties)
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         GF9 = galois.GF(3**2, display="poly")
-         print(GF9.properties)
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         GF9 = galois.GF(3**2, display="power")
-         print(GF9.properties)
+   GF9 = galois.GF(3**2)
+   print(GF9.properties)
 
 .. note::
 
@@ -54,31 +37,10 @@ exactly :math:`p^m` elements.
 
 The elements of the finite field are retrieved in a 1-D array using the :func:`~galois.FieldArray.Elements` classmethod.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         GF9.elements
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         GF9.elements
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         GF9.elements
+   GF9.elements
 
 Irreducible polynomial
 ----------------------
@@ -124,34 +86,11 @@ Here are :math:`a` and :math:`b` represented using :obj:`~galois.Poly` objects.
 Here are :math:`a` and :math:`b` represented as extension field elements. Extension field elements can be specified as integers
 or polynomial strings. See :doc:`/basic-usage/array-creation` for more details.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         a = GF9("x + 2"); a
-         b = GF9("x + 1"); b
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         a = GF9("x + 2"); a
-         b = GF9("x + 1"); b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         a = GF9("x + 2"); a
-         b = GF9("x + 1"); b
+   a = GF9("x + 2"); a
+   b = GF9("x + 1"); b
 
 Addition
 ........
@@ -162,64 +101,20 @@ the degree-:math:`m` polynomial :math:`f(x)`, since the quotient will always be 
 
 We can see that :math:`a + b = (1 + 1)x + (2 + 1) = 2x`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         a_poly + b_poly
-         a + b
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         a_poly + b_poly
-         a + b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         a_poly + b_poly
-         a + b
+   a_poly + b_poly
+   a + b
 
 The :obj:`galois` library includes the ability to display the arithmetic tables for any finite field. The table is only readable
 for small fields, but nonetheless the capability is provided. Select a few computations at random and convince yourself the
 answers are correct.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         print(GF9.arithmetic_table("+"))
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         print(GF9.arithmetic_table("+"))
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         print(GF9.arithmetic_table("+"))
+   print(GF9.arithmetic_table("+"))
 
 Subtraction
 ...........
@@ -228,62 +123,19 @@ Subtraction, like addition, is performed on coefficients degree-wise and will ne
 
 We can see that :math:`a - b = (1 - 1)x + (2 - 1) = 1`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         a_poly - b_poly
-         a - b
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         a_poly - b_poly
-         a - b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         a_poly - b_poly
-         a - b
+   a_poly - b_poly
+   a - b
 
 Here is the entire subtraction table for completeness.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
+   print(GF9.arithmetic_table("-"))
 
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         print(GF9.arithmetic_table("-"))
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         print(GF9.arithmetic_table("-"))
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         print(GF9.arithmetic_table("-"))
 
 Multiplication
 ..............
@@ -295,68 +147,20 @@ First compute :math:`ab = (x + 2)(x + 1) = x^2 + 2`. Notice that :math:`x^2 + 2`
 :math:`\mathrm{GF}(3^2)` can have degree at most 1. Therefore, reduction modulo :math:`f(x)` is required. After remainder
 division, we see that :math:`ab\ \equiv x\ \textrm{mod}\ f(x)`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         # Note the degree is greater than 1
-         a_poly * b_poly
-         (a_poly * b_poly) % f
-         a * b
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         # Note the degree is greater than 1
-         a_poly * b_poly
-         (a_poly * b_poly) % f
-         a * b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         # Note the degree is greater than 1
-         a_poly * b_poly
-         (a_poly * b_poly) % f
-         a * b
+   # Note the degree is greater than 1
+   a_poly * b_poly
+   (a_poly * b_poly) % f
+   a * b
 
 Here is the entire multiplication table for completeness.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         print(GF9.arithmetic_table("*"))
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         print(GF9.arithmetic_table("*"))
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         print(GF9.arithmetic_table("*"))
+   print(GF9.arithmetic_table("*"))
 
 Multiplicative inverse
 ......................
@@ -380,34 +184,11 @@ If :math:`a(x) = x + 1` is a field element of :math:`\mathrm{GF}(3^2)` and :math
 The :obj:`galois` library uses the Extended Euclidean Algorithm to compute multiplicative inverses (and division) in extension fields.
 The inverse of :math:`x + 1` in :math:`\mathrm{GF}(3^2)` can be easily computed in the following way.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         b ** -1
-         np.reciprocal(b)
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         b ** -1
-         np.reciprocal(b)
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         b ** -1
-         np.reciprocal(b)
+   b ** -1
+   np.reciprocal(b)
 
 Division
 ........
@@ -417,68 +198,20 @@ already learned multiplication and multiplicative inversion in finite fields.
 
 Let's compute :math:`a / b = (x + 2)(x + 1)^{-1}` in :math:`\mathrm{GF}(3^2)`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         _, b_inv_poly, _ = galois.egcd(b_poly, f)
-         (a_poly * b_inv_poly) % f
-         a * b**-1
-         a / b
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         _, b_inv_poly, _ = galois.egcd(b_poly, f)
-         (a_poly * b_inv_poly) % f
-         a * b**-1
-         a / b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         _, b_inv_poly, _ = galois.egcd(b_poly, f)
-         (a_poly * b_inv_poly) % f
-         a * b**-1
-         a / b
+   _, b_inv_poly, _ = galois.egcd(b_poly, f)
+   (a_poly * b_inv_poly) % f
+   a * b**-1
+   a / b
 
 Here is the division table for completeness. Notice that division is not defined for :math:`y = 0`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         print(GF9.arithmetic_table("/"))
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         print(GF9.arithmetic_table("/"))
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         print(GF9.arithmetic_table("/"))
+   print(GF9.arithmetic_table("/"))
 
 Primitive elements
 ------------------
@@ -495,34 +228,11 @@ A primitive element
 In :obj:`galois`, a primitive element of a finite field is provided by the :obj:`~galois.FieldArray.primitive_element`
 class property.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         print(GF9.properties)
-         g = GF9.primitive_element; g
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         print(GF9.properties)
-         g = GF9.primitive_element; g
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         print(GF9.properties)
-         g = GF9.primitive_element; g
+   print(GF9.properties)
+   g = GF9.primitive_element; g
 
 The :obj:`galois` package allows you to easily display all powers of an element and their equivalent polynomial, vector, and integer
 representations using :func:`~galois.FieldArray.repr_table`.
@@ -540,34 +250,11 @@ Other primitive elements
 There are multiple primitive elements of any finite field. All primitive elements are provided in the
 :obj:`~galois.FieldArray.primitive_elements` class property.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         GF9.primitive_elements
-         g = GF9("2x + 1"); g
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         GF9.primitive_elements
-         g = GF9("2x + 1"); g
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         GF9.primitive_elements
-         g = GF9("2x + 1"); g
+   GF9.primitive_elements
+   g = GF9("2x + 1"); g
 
 This means that :math:`x`, :math:`x + 2`, :math:`2x`, and :math:`2x + 1` all generate the multiplicative
 group :math:`\mathrm{GF}(3^2)^\times`. We can examine this by viewing the representation table using
@@ -590,40 +277,12 @@ orders less than :math:`p^m - 1`.
 For example, the element :math:`e = x + 1` is not a primitive element. It has :math:`\textrm{ord}(e) = 4`.
 Notice elements :math:`x`, :math:`x + 2`, :math:`2x`, and :math:`2x + 1` are not represented by the powers of :math:`e`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,poly,power
+   :name: GF9
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("int")
-         e = GF9("x + 1"); e
-
-   .. md-tab-item:: Polynomial
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("poly")
-         e = GF9("x + 1"); e
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF9.display("power")
-         e = GF9("x + 1"); e
+   e = GF9("x + 1"); e
 
 .. ipython:: python
 
    e.multiplicative_order()
    print(GF9.repr_table(e))
-
-..
-   Reset the display mode to the integer representation so other pages aren't affected
-.. ipython:: python
-   :suppress:
-
-   GF9.display("int")

--- a/docs/tutorials/intro-to-prime-fields.rst
+++ b/docs/tutorials/intro-to-prime-fields.rst
@@ -16,21 +16,11 @@ Prime field
 In this tutorial, we will consider the prime field :math:`\mathrm{GF}(7)`. Using the :obj:`galois` library, the :obj:`~galois.FieldArray`
 subclass `GF7` is created using the class factory :func:`~galois.GF`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         GF7 = galois.GF(7)
-         print(GF7.properties)
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         GF7 = galois.GF(7, display="power")
-         print(GF7.properties)
+   GF7 = galois.GF(7)
+   print(GF7.properties)
 
 .. note::
 
@@ -49,23 +39,10 @@ The elements of the finite field :math:`\mathrm{GF}(p)` are naturally represente
 
 The elements of the finite field are retrieved in a 1-D array using the :func:`~galois.FieldArray.Elements` classmethod.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         GF7.elements
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         GF7.elements
+   GF7.elements
 
 Arithmetic
 ----------
@@ -86,117 +63,51 @@ Here are :math:`a` and :math:`b` represented as Python integers.
 
 Here are :math:`a` and :math:`b` represented as prime field elements. See :doc:`/basic-usage/array-creation` for more details.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
+   a = GF7(3); a
+   b = GF7(5); b
 
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         a = GF7(3); a
-         b = GF7(5); b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         a = GF7(3); a
-         b = GF7(5); b
 
 Addition
 ........
 
 We can see that :math:`3 + 5 \equiv 1\ (\textrm{mod}\ 7)`. So accordingly, :math:`3 + 5 = 1` in :math:`\mathrm{GF}(7)`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
+   (a_int + b_int) % p
+   a + b
 
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         (a_int + b_int) % p
-         a + b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         (a_int + b_int) % p
-         a + b
 
 The :obj:`galois` library includes the ability to display the arithmetic tables for any finite field. The table is only readable
 for small fields, but nonetheless the capability is provided. Select a few computations at random and convince yourself the
 answers are correct.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         print(GF7.arithmetic_table("+"))
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         print(GF7.arithmetic_table("+"))
+   print(GF7.arithmetic_table("+"))
 
 Subtraction
 ...........
 
 As with addition, we can see that :math:`3 - 5 \equiv 5\ (\textrm{mod}\ 7)`. So accordingly, :math:`3 - 5 = 5` in :math:`\mathrm{GF}(7)`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         (a_int - b_int) % p
-         a - b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         (a_int - b_int) % p
-         a - b
+   (a_int - b_int) % p
+   a - b
 
 Here is the subtraction table for completeness.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         print(GF7.arithmetic_table("-"))
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         print(GF7.arithmetic_table("-"))
+   print(GF7.arithmetic_table("-"))
 
 Multiplication
 ..............
@@ -204,45 +115,18 @@ Multiplication
 Similarly, we can see that :math:`3 \cdot 5 \equiv 1\ (\textrm{mod}\ 7)`. So accordingly, :math:`3 \cdot 5 = 1`
 in :math:`\mathrm{GF}(7)`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         (a_int * b_int) % p
-         a * b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         (a_int * b_int) % p
-         a * b
+   (a_int * b_int) % p
+   a * b
 
 Here is the multiplication table for completeness.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         print(GF7.arithmetic_table("*"))
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         print(GF7.arithmetic_table("*"))
+   print(GF7.arithmetic_table("*"))
 
 Multiplicative inverse
 ......................
@@ -267,25 +151,11 @@ in :math:`\mathrm{GF}(7)`. Note, the GCD will always be 1 because :math:`y` is p
 The :obj:`galois` library uses the Extended Euclidean Algorithm to compute multiplicative inverses (and division) in prime fields.
 The inverse of 5 in :math:`\mathrm{GF}(7)` can be easily computed in the following way.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         b ** -1
-         np.reciprocal(b)
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         b ** -1
-         np.reciprocal(b)
+   b ** -1
+   np.reciprocal(b)
 
 Division
 ........
@@ -295,49 +165,20 @@ already learned multiplication and multiplicative inversion in finite fields.
 
 To compute :math:`3 / 5` in :math:`\mathrm{GF}(7)`, we can equivalently compute :math:`3 \cdot 5^{-1}` in :math:`\mathrm{GF}(7)`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         _, b_inv_int, _ = galois.egcd(b_int, p)
-         (a_int * b_inv_int) % p
-         a * b**-1
-         a / b
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         _, b_inv_int, _ = galois.egcd(b_int, p)
-         (a_int * b_inv_int) % p
-         a * b**-1
-         a / b
+   _, b_inv_int, _ = galois.egcd(b_int, p)
+   (a_int * b_inv_int) % p
+   a * b**-1
+   a / b
 
 Here is the division table for completeness. Notice that division is not defined for :math:`y = 0`.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         print(GF7.arithmetic_table("/"))
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         print(GF7.arithmetic_table("/"))
+   print(GF7.arithmetic_table("/"))
 
 Primitive elements
 ------------------
@@ -369,25 +210,11 @@ A primitive element
 In :obj:`galois`, a primitive element of a finite field is provided by the :obj:`~galois.FieldArray.primitive_element`
 class property.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         print(GF7.properties)
-         g = GF7.primitive_element; g
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         print(GF7.properties)
-         g = GF7.primitive_element; g
+   print(GF7.properties)
+   g = GF7.primitive_element; g
 
 The :obj:`galois` package allows you to easily display all powers of an element and their equivalent polynomial, vector, and integer
 representations using :func:`~galois.FieldArray.repr_table`. Let's ignore the polynomial and vector representations for now.
@@ -406,27 +233,12 @@ Other primitive elements
 There are multiple primitive elements of any finite field. All primitive elements are provided in the
 :obj:`~galois.FieldArray.primitive_elements` class property.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         list(galois.primitive_roots(7))
-         GF7.primitive_elements
-         g = GF7(5); g
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         list(galois.primitive_roots(7))
-         GF7.primitive_elements
-         g = GF7(5); g
+   list(galois.primitive_roots(7))
+   GF7.primitive_elements
+   g = GF7(5); g
 
 This means that 3 and 5 generate the multiplicative group :math:`\mathrm{GF}(7)^\times`.
 We can examine this by viewing the representation table using different generators.
@@ -447,23 +259,10 @@ orders less than :math:`p - 1`.
 
 For example, the element :math:`e = 2` is not a primitive element.
 
-.. md-tab-set::
+.. ipython-with-reprs:: int,power
+   :name: GF7
 
-   .. md-tab-item:: Integer
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("int")
-         e = GF7(2); e
-
-   .. md-tab-item:: Power
-
-      .. ipython:: python
-
-         @suppress
-         GF7.display("power")
-         e = GF7(2); e
+   e = GF7(2); e
 
 It has :math:`\textrm{ord}(e) = 3`. Notice elements 3, 5, and 6 are not represented by the powers of :math:`e`.
 
@@ -471,10 +270,3 @@ It has :math:`\textrm{ord}(e) = 3`. Notice elements 3, 5, and 6 are not represen
 
    e.multiplicative_order()
    print(GF7.repr_table(e))
-
-..
-   Reset the display mode to the integer representation so other pages aren't affected
-.. ipython:: python
-   :suppress:
-
-   GF7.display("int")

--- a/src/galois/_fields/_array.py
+++ b/src/galois/_fields/_array.py
@@ -35,7 +35,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
     --------
     Create a :obj:`~galois.FieldArray` subclass over :math:`\mathrm{GF}(3^5)` using the class factory :func:`~galois.GF`.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         GF = galois.GF(3**5)
         issubclass(GF, galois.FieldArray)
@@ -43,7 +43,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
     Create a :obj:`~galois.FieldArray` instance using `GF`'s constructor.
 
-    .. ipython:: python
+    .. ipython-with-reprs:: int,poly,power
 
         x = GF([44, 236, 206, 138]); x
         isinstance(x, GF)
@@ -88,6 +88,34 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
             The `order` keyword argument from :func:`numpy.array`. The default is `"K"`.
         ndmin
             The `ndmin` keyword argument from :func:`numpy.array`. The default is 0.
+
+        Examples
+        --------
+        Create a :obj:`~galois.FieldArray` subclass for :math:`\mathrm{GF}(3^5)`.
+
+        .. ipython-with-reprs:: int,poly,power
+
+            GF = galois.GF(3**5)
+            print(GF.properties)
+            alpha = GF.primitive_element; alpha
+
+        Create a finite field scalar from its integer representation, polynomial representation,
+        or a power of the primitive element.
+
+        .. ipython-with-reprs:: int,poly,power
+
+            GF(17)
+            GF("x^2 + 2x + 2")
+            alpha ** 222
+
+        Create a finite field array from its integer representation, polynomial representation,
+        or powers of the primitive element.
+
+        .. ipython-with-reprs:: int,poly,power
+
+            GF([17, 4, 148, 205])
+            GF([["x^2 + 2x + 2", 4], ["x^4 + 2x^3 + x^2 + x + 1", 205]])
+            alpha ** np.array([[222, 69], [54, 24]])
         """
         # pylint: disable=unused-argument,super-init-not-called
         # Adding __init__ and not doing anything is done to overwrite the superclass's __init__ docstring
@@ -226,13 +254,11 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         For extension fields, the increment is the integer increment between finite field elements in their :ref:`integer representation <int-repr>`.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly
 
-            GF = galois.GF(3**3, display="poly")
+            GF = galois.GF(3**3)
             GF.Range(10, 20)
             GF.Range(10, 20, 2)
-            @suppress
-            GF.display()
         """
     )
     def Range(
@@ -320,13 +346,15 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         Examples
         --------
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(2**3, display="power")
+            @suppress
+            np.set_printoptions(linewidth=200)
+            GF = galois.GF(2**3)
             a = GF.primitive_element; a
             V = GF.Vandermonde(a, 7, 7); V
             @suppress
-            GF.display()
+            np.set_printoptions(linewidth=75)
         """
         verify_isinstance(element, (int, np.integer, cls))
         verify_isinstance(rows, int)
@@ -369,13 +397,11 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         Examples
         --------
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(3**3, display="poly")
+            GF = galois.GF(3**3)
             a = GF.Vector([[1, 0, 2], [0, 2, 1]]); a
             a.vector()
-            @suppress
-            GF.display()
         """
         dtype = cls._get_dtype(dtype)
         order = cls.prime_subfield.order
@@ -523,63 +549,19 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         --------
         Arithmetic tables can be displayed using any element representation.
 
-        .. md-tab-set::
+        .. ipython-with-reprs:: int,poly,power
 
-            .. md-tab-item:: Integer
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2)
-                    print(GF.arithmetic_table("+"))
-
-            .. md-tab-item:: Polynomial
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2, display="poly")
-                    print(GF.arithmetic_table("+"))
-
-            .. md-tab-item:: Power
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2, display="power")
-                    print(GF.arithmetic_table("+"))
-                    @suppress
-                    GF.display()
+            GF = galois.GF(3**2)
+            print(GF.arithmetic_table("+"))
 
         An arithmetic table may also be constructed from arbitrary :math:`x` and :math:`y`.
 
-        .. md-tab-set::
+        .. ipython-with-reprs:: int,poly,power
 
-            .. md-tab-item:: Integer
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2)
-                    x = GF([7, 2, 8]); x
-                    y = GF([1, 4, 5, 3]); y
-                    print(GF.arithmetic_table("+", x=x, y=y))
-
-            .. md-tab-item:: Polynomial
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2, display="poly")
-                    x = GF([7, 2, 8]); x
-                    y = GF([1, 4, 5, 3]); y
-                    print(GF.arithmetic_table("+", x=x, y=y))
-
-            .. md-tab-item:: Power
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2, display="power")
-                    x = GF([7, 2, 8]); x
-                    y = GF([1, 4, 5, 3]); y
-                    print(GF.arithmetic_table("+", x=x, y=y))
-                    @suppress
-                    GF.display()
+            GF = galois.GF(3**2)
+            x = GF([7, 2, 8]); x
+            y = GF([1, 4, 5, 3]); y
+            print(GF.arithmetic_table("+", x=x, y=y))
         """
         if not operation in ["+", "-", "*", "/"]:
             raise ValueError(f"Argument 'operation' must be in ['+', '-', '*', '/'], not {operation!r}.")
@@ -783,14 +765,12 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         --------
         Compute the additive order of each element of :math:`\mathrm{GF}(3^2)`.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(3**2, display="poly")
+            GF = galois.GF(3**2)
             x = GF.elements; x
             order = x.additive_order(); order
             x * order
-            @suppress
-            GF.display()
         """
         x = self
         field = type(self)
@@ -832,9 +812,9 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         --------
         Compute the multiplicative order of each non-zero element of :math:`\mathrm{GF}(3^2)`.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(3**2, display="poly")
+            GF = galois.GF(3**2)
             x = GF.units; x
             order = x.multiplicative_order(); order
             x ** order
@@ -842,11 +822,9 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         The elements with :math:`\textrm{ord}(x) = 8` are multiplicative generators of :math:`\mathrm{GF}(3^2)^\times`,
         which are also called primitive elements.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
             GF.primitive_elements
-            @suppress
-            GF.display()
         """
         if not np.count_nonzero(self) == self.size:
             raise ArithmeticError("The multiplicative order of 0 is not defined.")
@@ -899,9 +877,9 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         --------
         Since :math:`\mathrm{GF}(2^3)` has characteristic 2, every element has a square root.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(2**3, display="poly")
+            GF = galois.GF(2**3)
             x = GF.elements; x
             x.is_square()
             @suppress
@@ -910,7 +888,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         In :math:`\mathrm{GF}(11)`, the characteristic is greater than 2 so only half of the elements have square
         roots.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,power
 
             GF = galois.GF(11)
             x = GF.elements; x
@@ -946,14 +924,12 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         Examples
         --------
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(3**3, display="poly")
+            GF = galois.GF(3**3)
             a = GF([11, 7]); a
             vec = a.vector(); vec
             GF.Vector(vec)
-            @suppress
-            GF.display()
         """
         field = type(self)
         subfield = field.prime_subfield
@@ -1337,13 +1313,11 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         --------
         Compute the field trace of the elements of :math:`\mathrm{GF}(3^2)`.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(3**2, display="poly")
+            GF = galois.GF(3**2)
             x = GF.elements; x
             y = x.field_trace(); y
-            @suppress
-            GF.display()
         """
         field = type(self)
         x = self
@@ -1386,13 +1360,11 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         --------
         Compute the field norm of the elements of :math:`\mathrm{GF}(3^2)`.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(3**2, display="poly")
+            GF = galois.GF(3**2)
             x = GF.elements; x
             y = x.field_norm(); y
-            @suppress
-            GF.display()
         """
         field = type(self)
         x = self
@@ -1442,7 +1414,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         --------
         The characteristic polynomial of the element :math:`a`.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
             GF = galois.GF(3**5)
             a = GF.Random(); a
@@ -1452,7 +1424,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         The characteristic polynomial of the square matrix :math:`\mathbf{A}`.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
             GF = galois.GF(3**5)
             A = GF.Random((3,3)); A
@@ -1500,7 +1472,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         --------
         The minimal polynomial of the element :math:`a`.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
             GF = galois.GF(3**5)
             a = GF.Random(); a
@@ -1543,9 +1515,9 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         Compute the logarithm of :math:`x` with default base :math:`\alpha`, which is the specified primitive element
         of the field.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(3**5, display="poly")
+            GF = galois.GF(3**5)
             alpha = GF.primitive_element; alpha
             x = GF.Random(10, low=1); x
             i = x.log(); i
@@ -1560,7 +1532,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
         Compute the logarithm of :math:`x` with a different base :math:`\beta`, which is another primitive element
         of the field.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
             beta = GF.primitive_elements[-1]; beta
             i = x.log(beta); i
@@ -1568,14 +1540,12 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         Compute the logarithm of a single finite field element base all of the primitive elements of the field.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
             x = GF.Random(low=1); x
             bases = GF.primitive_elements
             i = x.log(bases); i
             np.all(bases ** i == x)
-            @suppress
-            GF.display()
         """
         x = self
         field = type(self)
@@ -1611,33 +1581,11 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         Examples
         --------
-        .. md-tab-set::
+        .. ipython-with-reprs:: int,poly,power
 
-            .. md-tab-item:: Integer
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2)
-                    x = GF([4, 2, 7, 5])
-                    x
-
-            .. md-tab-item:: Polynomial
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2, display="poly")
-                    x = GF([4, 2, 7, 5])
-                    x
-
-            .. md-tab-item:: Power
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2, display="power")
-                    x = GF([4, 2, 7, 5])
-                    x
-                    @suppress
-                    GF.display()
+            GF = galois.GF(3**2)
+            x = GF([4, 2, 7, 5])
+            x
         """
         return self._display("repr")
 
@@ -1649,31 +1597,11 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         Examples
         --------
-        .. md-tab-set::
+        .. ipython-with-reprs:: int,poly,power
 
-            .. md-tab-item:: Integer
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2)
-                    x = GF([4, 2, 7, 5])
-                    print(x)
-
-            .. md-tab-item:: Polynomial
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2, display="poly")
-                    x = GF([4, 2, 7, 5])
-                    print(x)
-
-            .. md-tab-item:: Power
-
-                .. ipython:: python
-
-                    GF = galois.GF(3**2, display="power")
-                    x = GF([4, 2, 7, 5])
-                    print(x)
+            GF = galois.GF(3**2)
+            x = GF([4, 2, 7, 5])
+            print(x)
         """
         return self._display("str")
 

--- a/src/galois/_fields/_meta.py
+++ b/src/galois/_fields/_meta.py
@@ -203,19 +203,17 @@ class FieldArrayMeta(ArrayMeta):
         --------
         All elements of the prime field :math:`\mathrm{GF}(31)` in increasing order.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,power
 
             GF = galois.GF(31)
             GF.elements
 
         All elements of the extension field :math:`\mathrm{GF}(5^2)` in lexicographically-increasing order.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(5**2, display="poly")
+            GF = galois.GF(5**2)
             GF.elements
-            @suppress
-            GF.display()
         """
         return super().elements
 
@@ -228,19 +226,17 @@ class FieldArrayMeta(ArrayMeta):
         --------
         All units of the prime field :math:`\mathrm{GF}(31)` in increasing order.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,power
 
             GF = galois.GF(31)
             GF.units
 
         All units of the extension field :math:`\mathrm{GF}(5^2)` in lexicographically-increasing order.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(5**2, display="poly")
+            GF = galois.GF(5**2)
             GF.units
-            @suppress
-            GF.display()
         """
         return super().units
 
@@ -255,12 +251,19 @@ class FieldArrayMeta(ArrayMeta):
 
         Examples
         --------
-        .. ipython:: python
+        The smallest primitive element of the prime field :math:`\mathrm{GF}(31)`.
 
-            galois.GF(2).primitive_element
-            galois.GF(2**8).primitive_element
-            galois.GF(31).primitive_element
-            galois.GF(7**5).primitive_element
+        .. ipython-with-reprs:: int,power
+
+            GF = galois.GF(31)
+            GF.elements
+
+        The smallest primitive element of the extension field :math:`\mathrm{GF}(5^2)`.
+
+        .. ipython-with-reprs:: int,poly,power
+
+            GF = galois.GF(5**2)
+            GF.elements
         """
         return super().primitive_element
 
@@ -272,12 +275,19 @@ class FieldArrayMeta(ArrayMeta):
 
         Examples
         --------
-        .. ipython:: python
+        All primitive elements of the prime field :math:`\mathrm{GF}(31)` in increasing order.
 
-            galois.GF(2).primitive_elements
-            galois.GF(2**8).primitive_elements
-            galois.GF(31).primitive_elements
-            galois.GF(7**5).primitive_elements
+        .. ipython-with-reprs:: int,power
+
+            GF = galois.GF(31)
+            GF.elements
+
+        All primitive elements of the extension field :math:`\mathrm{GF}(5^2)` in lexicographically-increasing order.
+
+        .. ipython-with-reprs:: int,poly,power
+
+            GF = galois.GF(5**2)
+            GF.elements
         """
         if not hasattr(cls, "_primitive_elements"):
             n = cls.order - 1
@@ -301,21 +311,19 @@ class FieldArrayMeta(ArrayMeta):
         --------
         In fields with characteristic 2, every element is a square (with two identical square roots).
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(2**3, display="poly")
+            GF = galois.GF(2**3)
             x = GF.squares; x
             y1 = np.sqrt(x); y1
             y2 = -y1; y2
             np.array_equal(y1 ** 2, x)
             np.array_equal(y2 ** 2, x)
-            @suppress
-            GF.display()
 
         In fields with characteristic greater than 2, exactly half of the nonzero elements are squares
         (with two unique square roots).
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,power
 
             GF = galois.GF(11)
             x = GF.squares; x
@@ -344,16 +352,14 @@ class FieldArrayMeta(ArrayMeta):
         --------
         In fields with characteristic 2, no elements are non-squares.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,poly,power
 
-            GF = galois.GF(2**3, display="poly")
+            GF = galois.GF(2**3)
             GF.non_squares
-            @suppress
-            GF.display()
 
         In fields with characteristic greater than 2, exactly half of the nonzero elements are non-squares.
 
-        .. ipython:: python
+        .. ipython-with-reprs:: int,power
 
             GF = galois.GF(11)
             GF.non_squares

--- a/src/galois/typing.py
+++ b/src/galois/typing.py
@@ -25,7 +25,7 @@ Scalars are 0-D :obj:`~galois.Array` objects.
 
 - :obj:`int`: A finite field element in its :ref:`integer representation <int-repr>`.
 
-  .. ipython:: python
+  .. ipython-with-reprs:: int,poly,power
 
       GF = galois.GF(3**5)
       GF(17)
@@ -34,17 +34,22 @@ Scalars are 0-D :obj:`~galois.Array` objects.
   accepted, including: with/without `*`, with/without spaces, `^` or `**`, any indeterminate variable, increasing/decreasing
   degrees, etc. Or any combination of the above.
 
-  .. ipython:: python
+  .. ipython-with-reprs:: int,poly,power
 
       GF("x^2 + 2x + 2")
+
       # Add explicit * for multiplication
       GF("x^2 + 2*x + 2")
+
       # No spaces
       GF("x^2+2x+2")
+
       # ** instead of ^
       GF("x**2 + 2x + 2")
+
       # Different indeterminate
       GF("α^2 + 2α + 2")
+
       # Ascending degrees
       GF("2 + 2x + x^2")
 
@@ -64,7 +69,7 @@ A :obj:`~typing.Union` representing iterable objects that can be coerced into a 
 
 - :obj:`~typing.Sequence` [ :obj:`~galois.typing.ElementLike` ]: An iterable of elements.
 
-  .. ipython:: python
+  .. ipython-with-reprs:: int,poly,power
 
       GF = galois.GF(3**5)
       GF([17, 4])
@@ -73,7 +78,7 @@ A :obj:`~typing.Union` representing iterable objects that can be coerced into a 
 
 - :obj:`~typing.Sequence` [ :obj:`~galois.typing.IterableLike` ]: A recursive iterable of iterables of elements.
 
-  .. ipython:: python
+  .. ipython-with-reprs:: int,poly,power
 
       GF = galois.GF(3**5)
       GF([[17, 4], [148, 205]])
@@ -94,7 +99,7 @@ A :obj:`~typing.Union` representing objects that can be coerced into a Galois fi
 
 - :obj:`~galois.typing.IterableLike`: A recursive iterable of iterables of elements.
 
-  .. ipython:: python
+  .. ipython-with-reprs:: int,poly,power
 
       GF = galois.GF(3**5)
       GF([[17, 4], [148, 205]])
@@ -103,7 +108,7 @@ A :obj:`~typing.Union` representing objects that can be coerced into a Galois fi
 
 - :obj:`~numpy.ndarray`: A NumPy array of integers, representing finite field elements in their :ref:`integer representation <int-repr>`.
 
-  .. ipython:: python
+  .. ipython-with-reprs:: int,poly,power
 
       x = np.array([[17, 4], [148, 205]]); x
       GF(x)


### PR DESCRIPTION
Adds a custom Sphinx directive `ipython-with-reprs` to simplify a common pattern in the `galois` documentation where an example is performed in each element representation in separate tabs.

### Before

```rst
.. md-tab-set::

   .. md-tab-item:: Integer

      .. ipython:: python

         GF9 = galois.GF(3**2)
         print(GF9.properties)

   .. md-tab-item:: Polynomial

      .. ipython:: python

         GF9 = galois.GF(3**2, display="poly")
         print(GF9.properties)

   .. md-tab-item:: Power

      .. ipython:: python

         GF9 = galois.GF(3**2, display="power")
         print(GF9.properties)
```

### After

```rst
.. ipython-with-reprs:: int,poly,power
   :name: GF9

   GF9 = galois.GF(3**2)
   print(GF9.properties)
```

### Renders as (the same)

![image](https://user-images.githubusercontent.com/12112573/200607706-69279483-b434-4dd3-8aa7-0c2d0e7cfbd9.png)
