### PR TITLE
Parallelize JIT functions

### DIFF
--- a/src/galois/_domains/_function.py
+++ b/src/galois/_domains/_function.py
@@ -45,6 +45,9 @@ class Function:
     _SIGNATURE: numba.types.FunctionType
     """The function's Numba signature."""
 
+    _PARALLEL = False
+    """Indicates if parallel processing should be performed."""
+
     implementation: Callable
     """The function's implementation in pure Python."""
 
@@ -78,7 +81,7 @@ class Function:
 
         if key_2 not in self._CACHE[key_1]:
             self.set_globals()  # Set the globals once before JIT compiling the function
-            self._CACHE[key_1][key_2] = numba.jit(self._SIGNATURE.signature, nopython=True)(self.implementation)
+            self._CACHE[key_1][key_2] = numba.jit(self._SIGNATURE.signature, parallel=self._PARALLEL, nopython=True)(self.implementation)
 
         return self._CACHE[key_1][key_2]
 

--- a/src/galois/_domains/_linalg.py
+++ b/src/galois/_domains/_linalg.py
@@ -219,6 +219,7 @@ class matmul_jit(Function):
         MULTIPLY = self.field._multiply.ufunc_call_only
 
     _SIGNATURE = numba.types.FunctionType(int64[:,:](int64[:,:], int64[:,:]))
+    _PARALLEL = True
 
     @staticmethod
     def implementation(A, B):
@@ -228,8 +229,8 @@ class matmul_jit(Function):
         M, K = A.shape
         K, N = B.shape
         C = np.zeros((M, N), dtype=A.dtype)
-        for i in range(M):
-            for j in range(N):
+        for i in numba.prange(M):  # pylint: disable=not-an-iterable
+            for j in numba.prange(N):  # pylint: disable=not-an-iterable
                 for k in range(K):
                     C[i,j] = ADD(C[i,j], MULTIPLY(A[i,k], B[k,j]))
 

--- a/src/galois/_polys/_dense.py
+++ b/src/galois/_polys/_dense.py
@@ -428,11 +428,12 @@ class evaluate_elementwise_jit(Function):
         MULTIPLY = self.field._multiply.ufunc_call_only
 
     _SIGNATURE = numba.types.FunctionType(int64[:](int64[:], int64[:]))
+    _PARALLEL = True
 
     @staticmethod
     def implementation(coeffs, values):
         y = np.zeros(values.size, dtype=values.dtype)
-        for i in range(values.size):
+        for i in numba.prange(values.size):  # pylint: disable=not-an-iterable
             y[i] = coeffs[0]
             for j in range(1, coeffs.size):
                 y[i] = ADD(coeffs[j], MULTIPLY(y[i], values[i]))


### PR DESCRIPTION
Improves performance for #439.

### Matrix multiplication

```python
In [1]: import galois

In [2]: GF = galois.GF(2**16, compile="jit-calculate")

In [3]: A = GF.Random((500, 500), seed=1)

In [4]: A = GF.Random((300, 400), seed=1)

In [5]: B = GF.Random((400, 500), seed=2)

# Before
In [6]: %timeit A @ B
1.49 s ± 14.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# After
In [7]: %timeit A @ B
152 ms ± 732 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

### Polynomial evaluation

```python
In [1]: import galois

In [2]: GF = galois.GF(2**16, compile="jit-calculate")

In [3]: f = galois.Poly.Random(100, seed=1, field=GF)

In [4]: x = GF.Random(100_000, seed=1)

# Before
In [6]: %timeit f(x)
220 ms ± 745 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

# After
In [6]: %timeit f(x)
31.3 ms ± 1.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```