### PR TITLE
Fix a bug in factorization function causing infinite loops in rare cases

### DIFF
--- a/src/galois/_prime.py
+++ b/src/galois/_prime.py
@@ -840,8 +840,8 @@ def factors(n: int) -> tuple[list[int], list[int]]:
 
     # Step 4
     while n > 1 and not is_prime(n):
+        c = 1
         while True:
-            c = 1
             try:
                 f = pollard_rho(n, c=c)  # A non-trivial factor
                 break  # Found a factor


### PR DESCRIPTION
There is a small bug in factorization function when it gets to factors above 10M and starts calling `pollard_rho`. If it can't find a factor using `f(x)=x^2+c (mod n)`  with `c==1` it is supposed to update `c` to some other random value. But initialization accidentally got in the loop body and would always reset `c` back to `1`.

Since `pollard_rho` is only called to get factors larger than 10M at the point, and the fact that `c=1` usually works it is quite rare for this bug to surface, but in the rare case when `c=1` doesn't work it causes the infinite loop. Example would be `galois.GF(2400610585866217)` which requires factorization of `2400610585866217 - 1 = 2^3 * 3 * 100025441077759 = 2^3 * 3 * 10000537 * 10002007`.