### PR TITLE
Add `terms` kwarg to irreducible and primitive poly functions

### DIFF
--- a/src/galois/_polys/_irreducible.py
+++ b/src/galois/_polys/_irreducible.py
@@ -3,9 +3,7 @@ A module containing functions to generate and test irreducible polynomials.
 """
 from __future__ import annotations
 
-import functools
-import random
-from typing import TYPE_CHECKING, Iterator, Type
+from typing import Iterator
 
 from typing_extensions import Literal
 
@@ -14,14 +12,12 @@ from .._helper import export, verify_isinstance
 from .._prime import is_prime_power
 from ._poly import (
     Poly,
+    _deterministic_search,
     _deterministic_search_fixed_terms,
     _minimum_terms,
     _random_search,
     _random_search_fixed_terms,
 )
-
-if TYPE_CHECKING:
-    from .._fields import FieldArray
 
 
 @export
@@ -246,27 +242,9 @@ def irreducible_polys(
         field = _factory.FIELD_FACTORY(order)
 
         while True:
-            poly = _deterministic_search(field, start, stop, step)
+            poly = _deterministic_search(field, start, stop, step, "is_irreducible")
             if poly is not None:
                 start = int(poly) + step
                 yield poly
             else:
                 break
-
-
-@functools.lru_cache(maxsize=4096)
-def _deterministic_search(
-    field: Type[FieldArray],
-    start: int,
-    stop: int,
-    step: int,
-) -> Poly | None:
-    """
-    Searches for an irreducible polynomial in the range using the specified deterministic method.
-    """
-    for element in range(start, stop, step):
-        poly = Poly.Int(element, field=field)
-        if poly.is_irreducible():
-            return poly
-
-    return None

--- a/src/galois/_polys/_irreducible.py
+++ b/src/galois/_polys/_irreducible.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 
 import functools
 import random
-from typing import TYPE_CHECKING, Callable, Iterable, Iterator, Type
+from typing import TYPE_CHECKING, Iterator, Type
 
 from typing_extensions import Literal
 
-from .._domains import Array, _factory
+from .._domains import _factory
 from .._helper import export, verify_isinstance
 from .._prime import is_prime_power
-from ._poly import Poly
+from ._poly import Poly, _deterministic_search_fixed_terms, _minimum_terms
 
 if TYPE_CHECKING:
     from .._fields import FieldArray
@@ -262,98 +262,6 @@ def _deterministic_search(
             return poly
 
     return None
-
-
-@functools.lru_cache(maxsize=4096)
-def _minimum_terms(order: int, degree: int, test: str) -> int:
-    """
-    Finds the minimum number of terms of an irreducible or primitive polynomial of the specified degree over the
-    specified field.
-    """
-    if order == 2 and degree > 1:
-        # In GF(2), polynomials with even terms are always reducible. The only exception is x + 1.
-        start, stop, step = 1, degree + 2, 2
-    else:
-        start, stop, step = 1, degree + 2, 1
-
-    for terms in range(start, stop, step):
-        try:
-            # If a polynomial with the specified number of terms exists, then the current number of terms is
-            # the minimum number of terms.
-            next(_deterministic_search_fixed_terms(order, degree, terms, test))
-            return terms
-        except StopIteration:
-            # Continue to the next number of terms.
-            pass
-
-    poly_type = "irreducible" if test == "is_irreducible" else "primitive"
-    raise RuntimeError(
-        f"Could not find the minimum number of terms for a degree-{degree} {poly_type} polynomial over GF({order}). "
-        "This should never happen. Please open a GitHub issue."
-    )
-
-
-def _deterministic_search_fixed_terms(
-    order: int,
-    degree: int,
-    terms: int,
-    test: str,
-    reverse: bool = False,
-) -> Iterator[Poly]:
-    """
-    Iterates over all polynomials of the given degree and number of non-zero terms in lexicographical
-    order, only yielding those that pass the specified test (either 'is_irreducible()' or 'is_primitive()').
-    """
-    assert test in ["is_irreducible", "is_primitive"]
-    field = _factory.FIELD_FACTORY(order)
-
-    # A wrapper function around range to iterate forwards or backwards.
-    def direction(x):
-        if reverse:
-            return reversed(x)
-        return x
-
-    # Initialize the search by setting the first term to x^m with coefficient 1. This function will
-    # recursively add the remaining terms, with the last term being x^0.
-    yield from _deterministic_search_fixed_terms_recursive([degree], [1], terms - 1, test, field, direction)
-
-
-def _deterministic_search_fixed_terms_recursive(
-    degrees: Iterable[int],
-    coeffs: Iterable[int],
-    terms: int,
-    test: str,
-    field: Type[Array],
-    direction: Callable[[Iterable[int]], Iterable[int]],
-) -> Iterator[Poly]:
-    """
-    Recursively finds all polynomials having non-zero coefficients `coeffs` with degree `degrees` with `terms`
-    additional non-zero terms. The polynomials are found in lexicographical order, only yielding those that pass
-    the specified test (either 'is_irreducible()' or 'is_primitive()').
-    """
-    if terms == 0:
-        # There are no more terms, yield the polynomial.
-        poly = Poly.Degrees(degrees, coeffs, field=field)
-        if getattr(poly, test)():
-            yield poly
-    elif terms == 1:
-        # The last term must be the x^0 term, so we don't need to loop over possible degrees.
-        for coeff in direction(range(1, field.order)):
-            next_degrees = (*degrees, 0)
-            next_coeffs = (*coeffs, coeff)
-            yield from _deterministic_search_fixed_terms_recursive(
-                next_degrees, next_coeffs, terms - 1, test, field, direction
-            )
-    else:
-        # Find the next term's degree. It must be at least terms - 1 so that the polynomial can have the specified
-        # number of terms of lesser degree. It must also be less than the degree of the previous term.
-        for degree in direction(range(terms - 1, degrees[-1])):
-            for coeff in direction(range(1, field.order)):
-                next_degrees = (*degrees, degree)
-                next_coeffs = (*coeffs, coeff)
-                yield from _deterministic_search_fixed_terms_recursive(
-                    next_degrees, next_coeffs, terms - 1, test, field, direction
-                )
 
 
 def _random_search(order: int, degree: int, terms: int | None) -> Poly:

--- a/src/galois/_polys/_primitive.py
+++ b/src/galois/_polys/_primitive.py
@@ -13,8 +13,7 @@ from .._databases import ConwayPolyDatabase
 from .._domains import _factory
 from .._helper import export, verify_isinstance
 from .._prime import is_prime, is_prime_power
-from ._irreducible import _deterministic_search_fixed_terms, _minimum_terms
-from ._poly import Poly
+from ._poly import Poly, _deterministic_search_fixed_terms, _minimum_terms
 
 if TYPE_CHECKING:
     from .._fields import FieldArray

--- a/src/galois/_polys/_primitive.py
+++ b/src/galois/_polys/_primitive.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import functools
 import random
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator, Type
 
 from typing_extensions import Literal
 
@@ -15,23 +15,37 @@ from .._helper import export, verify_isinstance
 from .._prime import is_prime, is_prime_power
 from ._poly import Poly
 
+if TYPE_CHECKING:
+    from .._fields import FieldArray
+
 
 @export
-def primitive_poly(order: int, degree: int, method: Literal["min", "max", "random"] = "min") -> Poly:
+def primitive_poly(
+    order: int,
+    degree: int,
+    terms: int | None = None,
+    method: Literal["min", "max", "random"] = "min",
+) -> Poly:
     r"""
     Returns a monic primitive polynomial :math:`f(x)` over :math:`\mathrm{GF}(q)` with degree :math:`m`.
 
     Arguments:
         order: The prime power order :math:`q` of the field :math:`\mathrm{GF}(q)` that the polynomial is over.
         degree: The degree :math:`m` of the desired primitive polynomial.
+        terms: The desired number of non-zero terms :math:`t` in the polynomial. The default is `None` which disregards
+            the number of terms while searching for the polynomial.
         method: The search method for finding the primitive polynomial.
 
-            - `"min"` (default): Returns the lexicographically-minimal monic primitive polynomial.
-            - `"max"`: Returns the lexicographically-maximal monic primitive polynomial.
-            - `"random"`: Returns a randomly generated degree-:math:`m` monic primitive polynomial.
+            - `"min"` (default): Returns the lexicographically-first polynomial.
+            - `"max"`: Returns the lexicographically-last polynomial.
+            - `"random"`: Returns a random polynomial.
 
     Returns:
         The degree-:math:`m` monic primitive polynomial over :math:`\mathrm{GF}(q)`.
+
+    Raises:
+        RuntimeError: If no monic primitive polynomial of degree :math:`m` over :math:`\mathrm{GF}(q)` with
+            :math:`t` terms exists. If `terms=None`, this should never be raised.
 
     See Also:
         Poly.is_primitive, matlab_primitive_poly, conway_poly
@@ -46,7 +60,7 @@ def primitive_poly(order: int, degree: int, method: Literal["min", "max", "rando
         :math:`\mathrm{GF}(q^m) = \{0, 1, \alpha, \alpha^2, \dots, \alpha^{q^m-2}\}`.
 
     Examples:
-        Find the lexicographically minimal and maximal monic primitive polynomial. Also find a random monic primitive
+        Find the lexicographically first and last monic primitive polynomial. Also find a random monic primitive
         polynomial.
 
         .. ipython:: python
@@ -54,6 +68,12 @@ def primitive_poly(order: int, degree: int, method: Literal["min", "max", "rando
             galois.primitive_poly(7, 3)
             galois.primitive_poly(7, 3, method="max")
             galois.primitive_poly(7, 3, method="random")
+
+        Find a primitive polynomial with four terms.
+
+        .. ipython:: python
+
+            galois.primitive_poly(7, 3, terms=4)
 
         Notice :func:`~galois.primitive_poly` returns the lexicographically-minimal primitive polynomial but
         :func:`~galois.conway_poly` returns the lexicographically-minimal primitive polynomial that is *consistent*
@@ -86,6 +106,7 @@ def primitive_poly(order: int, degree: int, method: Literal["min", "max", "rando
     """
     verify_isinstance(order, int)
     verify_isinstance(degree, int)
+    verify_isinstance(terms, int, optional=True)
 
     if not is_prime_power(order):
         raise ValueError(f"Argument 'order' must be a prime power, not {order}.")
@@ -93,28 +114,42 @@ def primitive_poly(order: int, degree: int, method: Literal["min", "max", "rando
         raise ValueError(
             f"Argument 'degree' must be at least 1, not {degree}. There are no primitive polynomials with degree 0."
         )
+    if terms is not None and not 1 <= terms <= degree + 1:
+        raise ValueError(f"Argument 'terms' must be at least 1 and at most {degree + 1}, not {terms}.")
     if not method in ["min", "max", "random"]:
         raise ValueError(f"Argument 'method' must be in ['min', 'max', 'random'], not {method!r}.")
 
-    if method == "min":
-        poly = next(primitive_polys(order, degree))
-    elif method == "max":
-        poly = next(primitive_polys(order, degree, reverse=True))
-    else:
-        poly = _random_search(order, degree)
+    try:
+        if method == "min":
+            poly = next(primitive_polys(order, degree, terms))
+        elif method == "max":
+            poly = next(primitive_polys(order, degree, terms, reverse=True))
+        else:
+            poly = _random_search(order, degree, terms)
+    except StopIteration as e:
+        raise RuntimeError(
+            f"No monic primitive polynomial of degree {degree} over GF({order}) with {terms} terms exists."
+        ) from e
 
     return poly
 
 
 @export
-def primitive_polys(order: int, degree: int, reverse: bool = False) -> Iterator[Poly]:
+def primitive_polys(
+    order: int,
+    degree: int,
+    terms: int | None = None,
+    reverse: bool = False,
+) -> Iterator[Poly]:
     r"""
     Iterates through all monic primitive polynomials :math:`f(x)` over :math:`\mathrm{GF}(q)` with degree :math:`m`.
 
     Arguments:
         order: The prime power order :math:`q` of the field :math:`\mathrm{GF}(q)` that the polynomial is over.
         degree: The degree :math:`m` of the desired primitive polynomial.
-        reverse: Indicates to return the primitive polynomials from lexicographically maximal to minimal.
+        terms: The desired number of non-zero terms :math:`t` in the polynomials. The default is `None` which
+            disregards the number of terms while searching for the polynomials.
+        reverse: Indicates to return the primitive polynomials from lexicographically last to first.
             The default is `False`.
 
     Returns:
@@ -140,6 +175,12 @@ def primitive_polys(order: int, degree: int, reverse: bool = False) -> Iterator[
 
             list(galois.primitive_polys(3, 4))
 
+        Find all monic primitive polynomials with three terms.
+
+        .. ipython:: python
+
+            list(galois.primitive_polys(3, 4, terms=3))
+
         Loop over all the polynomials in reversed order, only finding them as needed. The search cost for the
         polynomials that would have been found after the `break` condition is never incurred.
 
@@ -164,12 +205,15 @@ def primitive_polys(order: int, degree: int, reverse: bool = False) -> Iterator[
     """
     verify_isinstance(order, int)
     verify_isinstance(degree, int)
+    verify_isinstance(terms, int, optional=True)
     verify_isinstance(reverse, bool)
 
     if not is_prime_power(order):
         raise ValueError(f"Argument 'order' must be a prime power, not {order}.")
     if not degree >= 0:
         raise ValueError(f"Argument 'degree' must be at least 0, not {degree}.")
+    if terms is not None and not 1 <= terms <= degree + 1:
+        raise ValueError(f"Argument 'terms' must be at least 1 and at most {degree + 1}, not {terms}.")
 
     field = _factory.FIELD_FACTORY(order)
 
@@ -182,7 +226,7 @@ def primitive_polys(order: int, degree: int, reverse: bool = False) -> Iterator[
         start, stop, step = stop - 1, start - 1, -1
 
     while True:
-        poly = _deterministic_search(field, start, stop, step)
+        poly = _deterministic_search(field, start, stop, step, terms)
         if poly is not None:
             start = int(poly) + step
             yield poly
@@ -191,19 +235,27 @@ def primitive_polys(order: int, degree: int, reverse: bool = False) -> Iterator[
 
 
 @functools.lru_cache(maxsize=4096)
-def _deterministic_search(field, start, stop, step) -> Poly | None:
+def _deterministic_search(
+    field: Type[FieldArray],
+    start: int,
+    stop: int,
+    step: int,
+    terms: int | None,
+) -> Poly | None:
     """
     Searches for a primitive polynomial in the range using the specified deterministic method.
     """
     for element in range(start, stop, step):
         poly = Poly.Int(element, field=field)
+        if terms is not None and poly.nonzero_coeffs.size != terms:
+            continue
         if poly.is_primitive():
             return poly
 
     return None
 
 
-def _random_search(order, degree) -> Poly:
+def _random_search(order: int, degree: int, terms: int | None) -> Poly:
     """
     Searches for a random primitive polynomial.
     """
@@ -216,6 +268,8 @@ def _random_search(order, degree) -> Poly:
     while True:
         integer = random.randint(start, stop - 1)
         poly = Poly.Int(integer, field=field)
+        if terms is not None and poly.nonzero_coeffs.size != terms:
+            continue
         if poly.is_primitive():
             return poly
 

--- a/src/galois/_polys/_primitive.py
+++ b/src/galois/_polys/_primitive.py
@@ -3,9 +3,7 @@ A module containing functions to generate and test primitive polynomials.
 """
 from __future__ import annotations
 
-import functools
-import random
-from typing import TYPE_CHECKING, Iterator, Type
+from typing import Iterator
 
 from typing_extensions import Literal
 
@@ -15,14 +13,12 @@ from .._helper import export, verify_isinstance
 from .._prime import is_prime, is_prime_power
 from ._poly import (
     Poly,
+    _deterministic_search,
     _deterministic_search_fixed_terms,
     _minimum_terms,
     _random_search,
     _random_search_fixed_terms,
 )
-
-if TYPE_CHECKING:
-    from .._fields import FieldArray
 
 
 @export
@@ -267,30 +263,12 @@ def primitive_polys(
         field = _factory.FIELD_FACTORY(order)
 
         while True:
-            poly = _deterministic_search(field, start, stop, step)
+            poly = _deterministic_search(field, start, stop, step, "is_primitive")
             if poly is not None:
                 start = int(poly) + step
                 yield poly
             else:
                 break
-
-
-@functools.lru_cache(maxsize=4096)
-def _deterministic_search(
-    field: Type[FieldArray],
-    start: int,
-    stop: int,
-    step: int,
-) -> Poly | None:
-    """
-    Searches for a primitive polynomial in the range using the specified deterministic method.
-    """
-    for element in range(start, stop, step):
-        poly = Poly.Int(element, field=field)
-        if poly.is_primitive():
-            return poly
-
-    return None
 
 
 @export

--- a/tests/polys/test_irreducible_polys.py
+++ b/tests/polys/test_irreducible_polys.py
@@ -1,6 +1,7 @@
 """
 A pytest module to test generating irreducible polynomials over finite fields.
 """
+import numpy as np
 import pytest
 
 import galois
@@ -86,6 +87,8 @@ def test_irreducible_poly_exceptions():
     with pytest.raises(ValueError):
         galois.irreducible_poly(2, 3, terms=6)
     with pytest.raises(ValueError):
+        galois.irreducible_poly(2, 3, terms="invalid-argument")
+    with pytest.raises(ValueError):
         galois.irreducible_poly(2, 3, method="invalid-argument")
 
 
@@ -120,6 +123,8 @@ def test_irreducible_polys_exceptions():
         next(galois.irreducible_polys(2, -1))
     with pytest.raises(ValueError):
         next(galois.irreducible_polys(2, 3, terms=6))
+    with pytest.raises(ValueError):
+        next(galois.irreducible_polys(2, 3, terms="invalid-argument"))
 
 
 @pytest.mark.parametrize("order,degree,polys", PARAMS)
@@ -143,6 +148,16 @@ def test_specific_terms_none_found():
         galois.irreducible_poly(2, 3, terms=2)
 
     assert not list(galois.irreducible_polys(2, 3, terms=2))
+
+
+@pytest.mark.parametrize("order,degree,polys", PARAMS)
+def test_minimum_terms(order, degree, polys):
+    min_terms = min(np.count_nonzero(f) for f in polys)
+    min_term_polys = [f for f in polys if np.count_nonzero(f) == min_terms]
+    assert [f.coeffs.tolist() for f in galois.irreducible_polys(order, degree, terms="min")] == min_term_polys
+
+    f = galois.irreducible_poly(order, degree, terms="min", method="random")
+    assert f.coeffs.tolist() in min_term_polys
 
 
 def test_large_degree():

--- a/tests/polys/test_irreducible_polys.py
+++ b/tests/polys/test_irreducible_polys.py
@@ -127,15 +127,15 @@ def test_irreducible_polys(order, degree, polys):
     assert [f.coeffs.tolist() for f in galois.irreducible_polys(order, degree)] == polys
 
 
-def test_specific_terms():
-    degree = 8
+@pytest.mark.parametrize("order,degree,polys", PARAMS)
+def test_specific_terms(order, degree, polys):
     all_polys = []
     for terms in range(1, degree + 2):
-        polys = list(galois.irreducible_polys(2, degree, terms=terms))
-        assert all(p.nonzero_coeffs.size == terms for p in polys)
-        all_polys += polys
+        new_polys = list(galois.irreducible_polys(order, degree, terms=terms))
+        assert all(p.nonzero_coeffs.size == terms for p in new_polys)
+        all_polys += new_polys
     all_polys = [p.coeffs.tolist() for p in sorted(all_polys, key=int)]
-    assert all_polys == IRREDUCIBLE_POLYS_2_8
+    assert all_polys == polys
 
 
 def test_specific_terms_none_found():

--- a/tests/polys/test_irreducible_polys.py
+++ b/tests/polys/test_irreducible_polys.py
@@ -76,10 +76,15 @@ def test_irreducible_poly_exceptions():
         galois.irreducible_poly(2.0, 3)
     with pytest.raises(TypeError):
         galois.irreducible_poly(2, 3.0)
+    with pytest.raises(TypeError):
+        galois.irreducible_poly(2, 3, terms=2.0)
+
     with pytest.raises(ValueError):
         galois.irreducible_poly(2**2 * 3**2, 3)
     with pytest.raises(ValueError):
         galois.irreducible_poly(2, 0)
+    with pytest.raises(ValueError):
+        galois.irreducible_poly(2, 3, terms=6)
     with pytest.raises(ValueError):
         galois.irreducible_poly(2, 3, method="invalid-argument")
 
@@ -105,16 +110,39 @@ def test_irreducible_polys_exceptions():
     with pytest.raises(TypeError):
         next(galois.irreducible_polys(2, 3.0))
     with pytest.raises(TypeError):
+        next(galois.irreducible_polys(2, 3, terms=2.0))
+    with pytest.raises(TypeError):
         next(galois.irreducible_polys(2, 3, reverse=1))
+
     with pytest.raises(ValueError):
         next(galois.irreducible_polys(2**2 * 3**2, 3))
     with pytest.raises(ValueError):
         next(galois.irreducible_polys(2, -1))
+    with pytest.raises(ValueError):
+        next(galois.irreducible_polys(2, 3, terms=6))
 
 
 @pytest.mark.parametrize("order,degree,polys", PARAMS)
 def test_irreducible_polys(order, degree, polys):
     assert [f.coeffs.tolist() for f in galois.irreducible_polys(order, degree)] == polys
+
+
+def test_specific_terms():
+    degree = 8
+    all_polys = []
+    for terms in range(1, degree + 2):
+        polys = list(galois.irreducible_polys(2, degree, terms=terms))
+        assert all(p.nonzero_coeffs.size == terms for p in polys)
+        all_polys += polys
+    all_polys = [p.coeffs.tolist() for p in sorted(all_polys, key=int)]
+    assert all_polys == IRREDUCIBLE_POLYS_2_8
+
+
+def test_specific_terms_none_found():
+    with pytest.raises(RuntimeError):
+        galois.irreducible_poly(2, 3, terms=2)
+
+    assert not list(galois.irreducible_polys(2, 3, terms=2))
 
 
 def test_large_degree():

--- a/tests/polys/test_primitive_polys.py
+++ b/tests/polys/test_primitive_polys.py
@@ -5,6 +5,7 @@ References
 ----------
 * https://baylor-ir.tdl.org/bitstream/handle/2104/8793/GF3%20Polynomials.pdf?sequence=1&isAllowed=y
 """
+import numpy as np
 import pytest
 
 import galois
@@ -90,6 +91,8 @@ def test_primitive_poly_exceptions():
     with pytest.raises(ValueError):
         galois.primitive_poly(2, 3, terms=6)
     with pytest.raises(ValueError):
+        galois.primitive_poly(2, 3, terms="invalid-argument")
+    with pytest.raises(ValueError):
         galois.primitive_poly(2, 3, method="invalid-argument")
 
 
@@ -124,6 +127,8 @@ def test_primitive_polys_exceptions():
         next(galois.primitive_polys(2, -1))
     with pytest.raises(ValueError):
         next(galois.primitive_polys(2, 3, terms=6))
+    with pytest.raises(ValueError):
+        next(galois.primitive_polys(2, 3, terms="invalid-argument"))
 
 
 @pytest.mark.parametrize("order,degree,polys", PARAMS)
@@ -147,6 +152,16 @@ def test_specific_terms_none_found():
         galois.primitive_poly(2, 3, terms=2)
 
     assert not list(galois.primitive_polys(2, 3, terms=2))
+
+
+@pytest.mark.parametrize("order,degree,polys", PARAMS)
+def test_minimum_terms(order, degree, polys):
+    min_terms = min(np.count_nonzero(f) for f in polys)
+    min_term_polys = [f for f in polys if np.count_nonzero(f) == min_terms]
+    assert [f.coeffs.tolist() for f in galois.primitive_polys(order, degree, terms="min")] == min_term_polys
+
+    f = galois.primitive_poly(order, degree, terms="min", method="random")
+    assert f.coeffs.tolist() in min_term_polys
 
 
 def test_conway_poly_exceptions():

--- a/tests/polys/test_primitive_polys.py
+++ b/tests/polys/test_primitive_polys.py
@@ -131,15 +131,15 @@ def test_primitive_polys(order, degree, polys):
     assert [f.coeffs.tolist() for f in galois.primitive_polys(order, degree)] == polys
 
 
-def test_specific_terms():
-    degree = 8
+@pytest.mark.parametrize("order,degree,polys", PARAMS)
+def test_specific_terms(order, degree, polys):
     all_polys = []
     for terms in range(1, degree + 2):
-        polys = list(galois.primitive_polys(2, degree, terms=terms))
-        assert all(p.nonzero_coeffs.size == terms for p in polys)
-        all_polys += polys
+        new_polys = list(galois.primitive_polys(order, degree, terms=terms))
+        assert all(p.nonzero_coeffs.size == terms for p in new_polys)
+        all_polys += new_polys
     all_polys = [p.coeffs.tolist() for p in sorted(all_polys, key=int)]
-    assert all_polys == PRIMITIVE_POLYS_2_8
+    assert all_polys == polys
 
 
 def test_specific_terms_none_found():

--- a/tests/polys/test_primitive_polys.py
+++ b/tests/polys/test_primitive_polys.py
@@ -80,10 +80,15 @@ def test_primitive_poly_exceptions():
         galois.primitive_poly(2.0, 3)
     with pytest.raises(TypeError):
         galois.primitive_poly(2, 3.0)
+    with pytest.raises(TypeError):
+        galois.primitive_poly(2, 3, terms=2.0)
+
     with pytest.raises(ValueError):
         galois.primitive_poly(2**2 * 3**2, 3)
     with pytest.raises(ValueError):
         galois.primitive_poly(2, 0)
+    with pytest.raises(ValueError):
+        galois.primitive_poly(2, 3, terms=6)
     with pytest.raises(ValueError):
         galois.primitive_poly(2, 3, method="invalid-argument")
 
@@ -109,16 +114,39 @@ def test_primitive_polys_exceptions():
     with pytest.raises(TypeError):
         next(galois.primitive_polys(2, 3.0))
     with pytest.raises(TypeError):
+        next(galois.primitive_polys(2, 3, terms=2.0))
+    with pytest.raises(TypeError):
         next(galois.primitive_polys(2, 3, reverse=1))
+
     with pytest.raises(ValueError):
         next(galois.primitive_polys(2**2 * 3**2, 3))
     with pytest.raises(ValueError):
         next(galois.primitive_polys(2, -1))
+    with pytest.raises(ValueError):
+        next(galois.primitive_polys(2, 3, terms=6))
 
 
 @pytest.mark.parametrize("order,degree,polys", PARAMS)
 def test_primitive_polys(order, degree, polys):
     assert [f.coeffs.tolist() for f in galois.primitive_polys(order, degree)] == polys
+
+
+def test_specific_terms():
+    degree = 8
+    all_polys = []
+    for terms in range(1, degree + 2):
+        polys = list(galois.primitive_polys(2, degree, terms=terms))
+        assert all(p.nonzero_coeffs.size == terms for p in polys)
+        all_polys += polys
+    all_polys = [p.coeffs.tolist() for p in sorted(all_polys, key=int)]
+    assert all_polys == PRIMITIVE_POLYS_2_8
+
+
+def test_specific_terms_none_found():
+    with pytest.raises(RuntimeError):
+        galois.primitive_poly(2, 3, terms=2)
+
+    assert not list(galois.primitive_polys(2, 3, terms=2))
 
 
 def test_conway_poly_exceptions():


### PR DESCRIPTION
Implements #458.

### Examples

```python
In [1]: import galois

In [2]: galois.irreducible_poly(7, 3)
Out[2]: Poly(x^3 + 2, GF(7))

In [3]: galois.irreducible_poly(7, 3, terms=3)
Out[3]: Poly(x^3 + x + 1, GF(7))

In [4]: galois.primitive_poly(7, 3)
Out[4]: Poly(x^3 + 3x + 2, GF(7))

In [5]: galois.primitive_poly(7, 3, terms=4)
Out[5]: Poly(x^3 + x^2 + x + 2, GF(7))
```

```python
In [1]: import galois

In [2]: list(galois.primitive_polys(3, 5))
Out[2]: 
[Poly(x^5 + 2x + 1, GF(3)),
 Poly(x^5 + 2x^2 + x + 1, GF(3)),       
 Poly(x^5 + x^3 + x + 1, GF(3)),        
 Poly(x^5 + x^3 + 2x^2 + 1, GF(3)),     
 Poly(x^5 + x^3 + 2x^2 + 2x + 1, GF(3)),
 Poly(x^5 + 2x^3 + x^2 + 1, GF(3)),     
 Poly(x^5 + 2x^3 + 2x^2 + x + 1, GF(3)),
 Poly(x^5 + x^4 + 2x + 1, GF(3)),
 Poly(x^5 + x^4 + x^2 + 1, GF(3)),
 Poly(x^5 + x^4 + x^2 + x + 1, GF(3)),
 Poly(x^5 + x^4 + x^3 + x + 1, GF(3)),
 Poly(x^5 + x^4 + x^3 + x^2 + 2x + 1, GF(3)),
 Poly(x^5 + x^4 + x^3 + 2x^2 + x + 1, GF(3)),
 Poly(x^5 + x^4 + 2x^3 + 1, GF(3)),
 Poly(x^5 + x^4 + 2x^3 + x^2 + x + 1, GF(3)),
 Poly(x^5 + x^4 + 2x^3 + 2x^2 + 1, GF(3)),
 Poly(x^5 + 2x^4 + 1, GF(3)),
 Poly(x^5 + 2x^4 + x + 1, GF(3)),
 Poly(x^5 + 2x^4 + 2x^2 + 2x + 1, GF(3)),
 Poly(x^5 + 2x^4 + x^3 + x^2 + x + 1, GF(3)),
 Poly(x^5 + 2x^4 + 2x^3 + 2x + 1, GF(3)),
 Poly(x^5 + 2x^4 + 2x^3 + x^2 + 1, GF(3))]

In [3]: list(galois.primitive_polys(3, 5, terms=4))
Out[3]: 
[Poly(x^5 + 2x^2 + x + 1, GF(3)),
 Poly(x^5 + x^3 + x + 1, GF(3)),
 Poly(x^5 + x^3 + 2x^2 + 1, GF(3)),
 Poly(x^5 + 2x^3 + x^2 + 1, GF(3)),
 Poly(x^5 + x^4 + 2x + 1, GF(3)),
 Poly(x^5 + x^4 + x^2 + 1, GF(3)),
 Poly(x^5 + x^4 + 2x^3 + 1, GF(3)),
 Poly(x^5 + 2x^4 + x + 1, GF(3))]

In [4]: list(galois.primitive_polys(3, 5, terms="min"))
Out[4]: [Poly(x^5 + 2x + 1, GF(3)), Poly(x^5 + 2x^4 + 1, GF(3))]
```

### Examples related to #464 

```python
In [1]: import galois

In [2]: galois.primitive_poly(2, 18)
Out[2]: Poly(x^18 + x^5 + x^2 + x + 1, GF(2))

In [3]: galois.primitive_poly(2, 18, terms="min")
Out[3]: Poly(x^18 + x^7 + 1, GF(2))

In [4]: galois.primitive_poly(2, 32)
Out[4]: Poly(x^32 + x^7 + x^5 + x^3 + x^2 + x + 1, GF(2))

In [5]: galois.primitive_poly(2, 32, terms="min")
Out[5]: Poly(x^32 + x^7 + x^6 + x^2 + 1, GF(2))

In [6]: galois.primitive_poly(2, 33)
Out[6]: Poly(x^33 + x^6 + x^4 + x + 1, GF(2))

In [7]: galois.primitive_poly(2, 33, terms="min")
Out[7]: Poly(x^33 + x^13 + 1, GF(2))

In [8]: galois.primitive_poly(2, 34)
Out[8]: Poly(x^34 + x^7 + x^6 + x^5 + x^2 + x + 1, GF(2))

In [9]: galois.primitive_poly(2, 34, terms="min")
Out[9]: Poly(x^34 + x^8 + x^4 + x^3 + 1, GF(2))
```