### PR TITLE
Fix array sizing in PLU decomposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://pypi.org/project/galois"><img src="https://img.shields.io/pypi/wheel/galois"></a>
   <a href="https://pypistats.org/packages/galois"><img src="https://img.shields.io/pypi/dm/galois"></a>
   <a href="https://pypi.org/project/galois"><img src="https://img.shields.io/pypi/l/galois"></a>
-  <a href="https://twitter.com/galois_py"><img src="https://img.shields.io/twitter/follow/galois_py?label=galois_py&style=flat&logo=twitter"></a>
+  <a href="https://twitter.com/galois_py"><img src="https://img.shields.io/static/v1?label=follow&message=@galois_py&color=lightgrey&logo=twitter"></a>
 </div>
 
 <div align=center>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://pypi.org/project/galois"><img src="https://img.shields.io/pypi/wheel/galois"></a>
   <a href="https://pypistats.org/packages/galois"><img src="https://img.shields.io/pypi/dm/galois"></a>
   <a href="https://pypi.org/project/galois"><img src="https://img.shields.io/pypi/l/galois"></a>
-  <a href="https://twitter.com/galois_py"><img src="https://img.shields.io/static/v1?label=follow&message=@galois_py&color=lightgrey&logo=twitter"></a>
+  <a href="https://twitter.com/galois_py"><img src="https://img.shields.io/static/v1?label=follow&message=@galois_py&color=blue&logo=twitter"></a>
 </div>
 
 <div align=center>

--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -1,8 +1,8 @@
 {% extends "!base.html" %}
 
 {% block outdated %}
-  You're not viewing the latest version.
-  <a href="{{ '../' ~ base_url}}">
-    <strong>Click here to go to latest.</strong>
-  </a>
+You're not viewing the latest version.
+<a href="{{ '../' ~ base_url}}">
+  <strong>Click here to go to latest.</strong>
+</a>
 {% endblock %}

--- a/src/galois/_domains/_linalg.py
+++ b/src/galois/_domains/_linalg.py
@@ -343,13 +343,13 @@ class plu_decompose_jit(Function):
         if not A.ndim == 2:
             raise ValueError(f"Argument 'A' must be a 2-D matrix, not have shape {A.shape}.")
 
-        n = A.shape[0]
+        m, n = A.shape
         Ai = A.copy()
-        L = self.field.Zeros((n, n))
-        P = self.field.Identity(n)  # Row permutation matrix
+        L = self.field.Zeros((m, m))
+        P = self.field.Identity(m)  # Row permutation matrix
         N_permutations = 0  # Number of permutations
 
-        for i in range(0, n - 1):
+        for i in range(0, min(m, n)):
             if Ai[i, i] == 0:
                 idxs = np.nonzero(Ai[i:, i])[0]  # The first non-zero entry in column `i` below row `i`
                 if idxs.size == 0:

--- a/src/galois/_domains/_linalg.py
+++ b/src/galois/_domains/_linalg.py
@@ -322,7 +322,7 @@ class lu_decompose_jit(Function):
                     L[i, i] = 1
                     continue
                 else:
-                    raise ValueError("The LU decomposition of 'A' does not exist. Use the LUP decomposition instead.")
+                    raise ValueError("The LU decomposition of 'A' does not exist. Use the PLU decomposition instead.")
 
             l = Ai[i + 1 :, i] / Ai[i, i]
             Ai[i + 1 :, :] -= np.multiply.outer(l, Ai[i, :])

--- a/src/galois/_domains/_linalg.py
+++ b/src/galois/_domains/_linalg.py
@@ -311,11 +311,11 @@ class lu_decompose_jit(Function):
         if not A.ndim == 2:
             raise ValueError(f"Argument 'A' must be a 2-D matrix, not have shape {A.shape}.")
 
-        n = A.shape[0]
+        m = A.shape[0]
         Ai = A.copy()
-        L = self.field.Identity(n)
+        L = self.field.Identity(m)
 
-        for i in range(0, n - 1):
+        for i in range(0, m - 1):
             if Ai[i, i] == 0:
                 idxs = np.nonzero(Ai[i:, i])[0]  # The first non-zero entry in column `i` below row `i`
                 if idxs.size == 0:  # pylint: disable=no-else-continue

--- a/tests/fields/test_linalg.py
+++ b/tests/fields/test_linalg.py
@@ -369,6 +369,28 @@ def test_plu_decompose(field_plu_decompose):
         assert type(u) is GF
 
 
+def test_bug_476():
+    """
+    See https://github.com/mhostetter/galois/issues/476.
+    """
+    GF = galois.GF(2)
+    A = GF(
+        [
+            [1, 0, 0, 0, 0, 1],
+            [1, 1, 1, 1, 0, 1],
+            [1, 0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0, 0],
+            [0, 0, 1, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 0, 1],
+        ]
+    )
+    P, L, U = A.plu_decompose()
+    PLU = P @ L @ U
+    assert np.array_equal(A, PLU)
+
+
 def test_matrix_inverse_exceptions():
     GF = galois.GF(2**8)
     with pytest.raises(np.linalg.LinAlgError):


### PR DESCRIPTION
Fixes #476.

```python
# bug_476.py
import numpy as np

import galois

GF = galois.GF(2)

A = GF(
    [
        [1, 0, 0, 0, 0, 1],
        [1, 1, 1, 1, 0, 1],
        [1, 0, 0, 0, 0, 0],
        [0, 1, 0, 0, 0, 0],
        [0, 0, 1, 0, 0, 0],
        [0, 0, 0, 1, 0, 0],
        [0, 0, 0, 0, 1, 0],
        [0, 0, 0, 0, 0, 1],
    ]
)
print(f"A = \n{A}")

P, L, U = A.plu_decompose()
print(f"P = \n{P}")
print(f"L = \n{L}")
print(f"U = \n{U}")

PLU = P @ L @ U
print(f"PLU = \n{PLU}")
print(np.array_equal(A, PLU))
```

```console
$ python3 bug_476.py
A = 
[[1 0 0 0 0 1]
 [1 1 1 1 0 1]
 [1 0 0 0 0 0]
 [0 1 0 0 0 0]
 [0 0 1 0 0 0]
 [0 0 0 1 0 0]
 [0 0 0 0 1 0]
 [0 0 0 0 0 1]]
P = 
[[1 0 0 0 0 0 0 0]
 [0 1 0 0 0 0 0 0]
 [0 0 0 0 0 1 0 0]
 [0 0 1 0 0 0 0 0]
 [0 0 0 1 0 0 0 0]
 [0 0 0 0 0 0 1 0]
 [0 0 0 0 1 0 0 0]
 [0 0 0 0 0 0 0 1]]
L = 
[[1 0 0 0 0 0 0 0]
 [1 1 0 0 0 0 0 0]
 [0 1 1 0 0 0 0 0]
 [0 0 1 1 0 0 0 0]
 [0 0 0 0 1 0 0 0]
 [1 0 0 0 0 1 0 0]
 [0 0 0 1 0 0 0 0]
 [0 0 0 0 0 1 0 1]]
U =
[[1 0 0 0 0 1]
 [0 1 1 1 0 0]
 [0 0 1 1 0 0]
 [0 0 0 1 0 0]
 [0 0 0 0 1 0]
 [0 0 0 0 0 1]
 [0 0 0 0 0 0]
 [0 0 0 0 0 0]]
PLU =
[[1 0 0 0 0 1]
 [1 1 1 1 0 1]
 [1 0 0 0 0 0]
 [0 1 0 0 0 0]
 [0 0 1 0 0 0]
 [0 0 0 1 0 0]
 [0 0 0 0 1 0]
 [0 0 0 0 0 1]]
True
```