### PR TITLE
Removes deprecation warnings from numpy 1.25

### DIFF
--- a/tests/fields/conftest.py
+++ b/tests/fields/conftest.py
@@ -484,6 +484,8 @@ def randint(low, high, shape, dtype):
         iterator = np.nditer(array, flags=["multi_index", "refs_ok"])
         for _ in iterator:
             array[iterator.multi_index] = random.randint(low, high - 1)
+    if isinstance(shape, int) and shape == 1:
+        return array.item()
     return array
 
 


### PR DESCRIPTION
Related to #491.

Not sure if this affects older supported versions, and it's also not that easy for me to check locally, so let's see with the Github CI.