### PR TITLE
Implementation of wheel factorization

### DIFF
--- a/src/galois/_prime.py
+++ b/src/galois/_prime.py
@@ -170,17 +170,15 @@ def prev_prime(n: int) -> int:
     if n <= MAX_N:
         return PRIMES[bisect.bisect_right(PRIMES, n) - 1]
 
-    shifts = [29, 23, 19, 17, 13, 11, 7, 1] # Factorization wheel for basis {2, 3, 5}
-    base = n // 30 * 30 # Wheel factorization starting point
-    found = False # Success flag
+    shifts = [29, 23, 19, 17, 13, 11, 7, 1]  # Factorization wheel for basis {2, 3, 5}
+    base = n // 30 * 30  # Wheel factorization starting point
+    found = False  # Success flag
 
     while not found:
         for shift in shifts:
-            i = base + shift # May be bigger than n
-
+            i = base + shift  # May be bigger than n
             if i >= n:
                 continue
-
             if is_prime(i):
                 found = True
                 break
@@ -219,17 +217,15 @@ def next_prime(n: int) -> int:
     if n < PRIMES[-1]:
         return PRIMES[bisect.bisect_right(PRIMES, n)]
 
-    shifts = [1, 7, 11, 13, 17, 19, 23, 29] # Factorization wheel for basis {2, 3, 5}
-    base = n // 30 * 30 # Wheel factorization starting point. May be less than n.
-    found = False # Success flag
+    shifts = [1, 7, 11, 13, 17, 19, 23, 29]  # Factorization wheel for basis {2, 3, 5}
+    base = n // 30 * 30  # Wheel factorization starting point. May be less than n.
+    found = False  # Success flag
 
     while not found:
         for shift in shifts:
             i = base + shift
-
             if i <= n:
                 continue
-
             if is_prime(i):
                 found = True
                 break

--- a/src/galois/_prime.py
+++ b/src/galois/_prime.py
@@ -170,14 +170,23 @@ def prev_prime(n: int) -> int:
     if n <= MAX_N:
         return PRIMES[bisect.bisect_right(PRIMES, n) - 1]
 
-    # TODO: Make this faster using wheel factorization
-    n = n - 1 if n % 2 == 0 else n  # The next possible prime (which is odd)
-    while True:
-        n -= 2  # Only check odds
-        if is_prime(n):
-            break
+    shifts = [29, 23, 19, 17, 13, 11, 7, 1] # Factorization wheel for basis {2, 3, 5}
+    base = n // 30 * 30 # Wheel factorization starting point
+    found = False # Success flag
 
-    return n
+    while not found:
+        for shift in shifts:
+            i = base + shift # May be bigger than n
+
+            if i >= n:
+                continue
+
+            if is_prime(i):
+                found = True
+                break
+        base -= 30
+
+    return i
 
 
 @export
@@ -210,14 +219,23 @@ def next_prime(n: int) -> int:
     if n < PRIMES[-1]:
         return PRIMES[bisect.bisect_right(PRIMES, n)]
 
-    # TODO: Make this faster using wheel factorization
-    n = n + 1 if n % 2 == 0 else n + 2  # The next possible prime (which is odd)
-    while True:
-        n += 2  # Only check odds
-        if is_prime(n):
-            break
+    shifts = [1, 7, 11, 13, 17, 19, 23, 29] # Factorization wheel for basis {2, 3, 5}
+    base = n // 30 * 30 # Wheel factorization starting point. May be less than n.
+    found = False # Success flag
 
-    return n
+    while not found:
+        for shift in shifts:
+            i = base + shift
+
+            if i <= n:
+                continue
+
+            if is_prime(i):
+                found = True
+                break
+        base += 30
+
+    return i
 
 
 @export

--- a/tests/test_primes.py
+++ b/tests/test_primes.py
@@ -58,6 +58,17 @@ def test_next_prime(next_prime):
         assert galois.next_prime(x) == z
 
 
+def test_next_prime_bug_528():
+    """
+    https://github.com/mhostetter/galois/issues/528
+    """
+    assert galois.next_prime(100000034) == 100000037
+    assert galois.next_prime(100000035) == 100000037
+    assert galois.next_prime(100000036) == 100000037
+    assert galois.next_prime(100000037) == 100000039
+    assert galois.next_prime(100000038) == 100000039
+
+
 def test_random_prime_exceptions():
     with pytest.raises(TypeError):
         galois.random_prime(10.0)


### PR DESCRIPTION
Also, it fixes the bug of skipping the first two numbers after n. For example, in the previous version:

>>> galois.next_prime(100000034)
100000037
>>> galois.next_prime(100000035)
100000039
>>> galois.next_prime(100000036)
100000039
>>> galois.next_prime(100000037)
100000049