### PR TITLE
Linear system solver for GF2

### DIFF
--- a/src/galois/_fields/_gf2.py
+++ b/src/galois/_fields/_gf2.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from .._domains._function import Function
 from .._domains._lookup import (
     add_ufunc,
     divide_ufunc,
@@ -17,7 +18,6 @@ from .._domains._lookup import (
     subtract_ufunc,
 )
 from .._domains._ufunc import UFuncMixin
-from .._domains._function import Function
 from .._helper import export
 from ._array import FieldArray
 

--- a/src/galois/_fields/_gf2.py
+++ b/src/galois/_fields/_gf2.py
@@ -153,9 +153,18 @@ class FieldArray_2_1(FieldArray):
     A FieldArray class wrapper that provides explicit solve function for GF(2).
     """
 
+    _OVERRIDDEN_FUNCTIONS = {
+        **FieldArray._OVERRIDDEN_FUNCTIONS,
+        **{
+            np.linalg.lstsq: "_lstsq",
+        },
+    }
+
+    _lstsq: Function
+
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
-        cls._solve = solve(cls)
+        cls._lstsq = solve(cls)
 
 
 @export


### PR DESCRIPTION
I needed a solver for linear systems over GF2 for simple codes decoding, but the library only has a solver that just inverts the coefficient matrix A requiring matrix A be square. I found [this](https://github.com/scheinerman/SimpleGF2.jl/blob/master/src/solving.jl#L71) solution in Julia and translated it. The solve function can be invoked  using `np.linalg.solve` (i.e. `galois.GF2._solve`) and using `galois.GF2._solve`. As I modified the old function calling style I would say that it works (build succeeded), and it works well in may project.