### PR TITLE
Convert to int for faster mod

### DIFF
--- a/src/galois/_domains/_linalg.py
+++ b/src/galois/_domains/_linalg.py
@@ -58,6 +58,12 @@ def _lapack_linalg(field: Type[Array], a: Array, b: Array, function, out=None, n
         c = function(a, b)
     else:
         c = function(a, b, out=out)
+
+    if dtype in [np.float32, np.float64]:
+        # Performing the modulo operation on an int is faster than a float. Convert back to int64 for the time
+        # savings, if possible.
+        c = c.astype(np.int64)
+
     c = c % field.characteristic  # Reduce the result mod p
 
     if np.isscalar(c):


### PR DESCRIPTION
This is a follow up to #596 

The reason that no speedup was observed [here](https://github.com/mhostetter/galois/pull/596#issuecomment-2798902141) is the small outer dimension `dim1=10`. Here, `c` is just a 10 x 10 matrix, so the modulo operation is negligible compared to inner index contraction.

When the outer dimensions are similar or large compared to the inner dimensions, the modulo operation can be time intensive. And here, integer conversion definitely saves time:
```python
import numpy as np

a_int = np.random.randint(0, 2**9, (2000, 4000))
a_float = a_int.astype(np.float64)

%timeit a_int % 2  # 12.1 ms ± 576 μs per loop
%timeit a_float % 2  # 196 ms ± 7.13 ms per loop
```

A benchmark script:
```python
import galois

dim1 = 1000

for p in [1_009,]:
    GF = galois.GF(p)

    for dim2 in [10, 100, 1000]:
        A = GF.Random((dim1, dim2))
        B = GF.Random((dim2, dim1))
        print(p, dim1, dim2)
        %timeit A @ B
```

Output on main:
```
1009 1000 10
44.9 ms ± 1.36 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
1009 1000 100
45.4 ms ± 866 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
1009 1000 1000
77.8 ms ± 4.17 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Output for this PR:
```
1009 1000 10
9.31 ms ± 3.39 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
1009 1000 100
9.34 ms ± 476 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
1009 1000 1000
32.4 ms ± 3.09 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

So I'm seeing 2-5x speedup for these examples.

[Profiler](https://marketplace.visualstudio.com/items?itemName=rafaelha.vscode-flamegraph) results for [1000, 10] @ [10, 1000] matmul:

<img width="546" alt="image" src="https://github.com/user-attachments/assets/617ff62c-a219-4f71-bc97-c89508851783" />

<img width="532" alt="image" src="https://github.com/user-attachments/assets/ad48ab5a-5024-4b6d-b219-5aa0a367e101" />


