### PR TITLE
Pickling of Galois Fields

### DIFF
--- a/src/galois/_fields/_array.py
+++ b/src/galois/_fields/_array.py
@@ -1731,7 +1731,7 @@ class FieldArray(Array, metaclass=FieldArrayMeta):
 
         if np.isscalar(output):
             output = int(output)
-        if output.dtype == np.object_:
+        elif output.dtype == np.object_:
             output = output.astype(int)
 
         return output

--- a/tests/fields/test_arithmetic.py
+++ b/tests/fields/test_arithmetic.py
@@ -206,6 +206,8 @@ def test_log(field_log):
     assert np.array_equal(z, Z)
     z = x.log()
     assert np.array_equal(z, Z)
+    #Bug 599.  Make sure log() works for scalar inputs.
+    assert x[0].log() == Z[0]
 
 
 def test_log_different_base(field_log):
@@ -217,6 +219,8 @@ def test_log_different_base(field_log):
     beta = GF.primitive_elements[-1]
     z = x.log(beta)
     assert np.array_equal(beta**z, x)
+    #Bug 599.  Make sure log() works for scalar inputs.
+    assert beta ** (x[0].log(beta)) == x[0]
 
 
 @pytest.mark.parametrize("ufunc_mode", ["jit-calculate", "python-calculate"])

--- a/tests/fields/test_arithmetic.py
+++ b/tests/fields/test_arithmetic.py
@@ -206,7 +206,7 @@ def test_log(field_log):
     assert np.array_equal(z, Z)
     z = x.log()
     assert np.array_equal(z, Z)
-    #Bug 599.  Make sure log() works for scalar inputs.
+    # Bug 599.  Make sure log() works for scalar inputs.
     assert x[0].log() == Z[0]
 
 
@@ -219,7 +219,7 @@ def test_log_different_base(field_log):
     beta = GF.primitive_elements[-1]
     z = x.log(beta)
     assert np.array_equal(beta**z, x)
-    #Bug 599.  Make sure log() works for scalar inputs.
+    # Bug 599.  Make sure log() works for scalar inputs.
     assert beta ** (x[0].log(beta)) == x[0]
 
 


### PR DESCRIPTION
Fix bug #539. 

Galois fields couldn't be reliably pickled at all because they create types on the fly. A field could only be pickled if it already existed.  This changes the pickling of Galois fields so that they are created using `galois.GF`.

Tests added.