### PR TITLE
Only add `np.trapz` when NumPy < 2.4.0

### DIFF
--- a/src/galois/_domains/_function.py
+++ b/src/galois/_domains/_function.py
@@ -311,7 +311,6 @@ class FunctionMixin(np.ndarray, metaclass=ArrayMeta):
         np.round,
         np.fix,
         np.gradient,
-        np.trapz,
         np.i0,
         np.sinc,
         np.angle,
@@ -323,6 +322,11 @@ class FunctionMixin(np.ndarray, metaclass=ArrayMeta):
         np.lib.scimath.logn,
         np.cross,
     ]
+
+    if np.lib.NumpyVersion(np.__version__) < "2.4.0":
+        _UNSUPPORTED_FUNCTIONS.append(np.trapz)
+    else:
+        _UNSUPPORTED_FUNCTIONS.append(np.trapezoid)
 
     _FUNCTIONS_REQUIRING_VIEW = [
         np.concatenate,


### PR DESCRIPTION
NumPy 2.4.0 removed `np.trapz`, which was deprecated since NumPy 2.0. Even though this is not used by Galois, it cannot be imported and tests fail to run when NumPy 2.4.0 is installed.

This commit fixes #636 by appending the right function to the `_UNSUPPORTED_FUNCTIONS` list depending on NumPy's version.