### PR TITLE
Fix error message when missing positional arguments calling GF()

### DIFF
--- a/src/galois/_fields/_factory.py
+++ b/src/galois/_fields/_factory.py
@@ -257,9 +257,7 @@ def GF(
         verify_isinstance(characteristic, int)
         verify_isinstance(degree, int)
     elif len(args) == 0:
-        raise TypeError(
-            "Missing required positional argument 'order' or arguments 'characteristic' and 'degree'."
-        )
+        raise TypeError("Missing required positional argument 'order' or arguments 'characteristic' and 'degree'.")
     else:
         assert len(args) > 2
         raise TypeError(

--- a/src/galois/_fields/_factory.py
+++ b/src/galois/_fields/_factory.py
@@ -256,7 +256,12 @@ def GF(
         characteristic, degree = args
         verify_isinstance(characteristic, int)
         verify_isinstance(degree, int)
+    elif len(args) == 0:
+        raise TypeError(
+            "Missing required positional argument 'order' or arguments 'characteristic' and 'degree'."
+        )
     else:
+        assert len(args) > 2
         raise TypeError(
             "Only 'order' or 'characteristic' and 'degree' may be specified as positional arguments. "
             "Other arguments must be specified as keyword arguments."


### PR DESCRIPTION
## Summary

Fixes a confusing error message when missing positional arguments calling GF().

The motivating example is that someone might try to construct a field with just an irreducible polynomial, like this:

    galois.GF(irreducible_poly='x^2+x+1')

which produces the following error:

> TypeError: Only 'order' or 'characteristic' and 'degree' may be specified as positional arguments. Other arguments must be specified as keyword arguments.

This falsely suggests that too many positional arguments have been specified while in reality the problem is that the positional arguments are missing. This commit changes the error message to:

> TypeError: Missing required positional argument 'order' or arguments 'characteristic' and 'degree'.

which explains the problem more clearly and is more consistent with the error message that Python would generate when a required positional argument is missing.

## Type

- [X] Fix (bug / correctness)
- [ ] Feature (new capability)
- [ ] Performance
- [ ] Docs / tooling / CI
- [ ] Refactor (no behavior change)

(I don't really know how to classify this; the old behavior isn't exactly buggy. The new behaviour is just more user-friendly.)

## Release notes

- [ ] Not user-facing (no entry needed)
- [ ] Added entry to `docs/release-notes/unreleased.md`

(Too trivial to add a release note.)

## Testing

- [ ] Added/updated tests
- [X] `pytest` (command / notes):
- [x] Other validation (benchmarks, docs build, examples): manually tested

(Not sure if it's worth adding a unit test for this.)

## Backwards compatibility

- [X] No breaking changes
- [ ] Potentially breaking (describe + rationale)

## Checklist

- [x] PR base branch is `develop`
- [ ] CI is green
- [ ] Docs/docstrings updated where appropriate
