### PR TITLE
Fix IndexError in characteristic_poly/minimal_poly for 1x1 matrices

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -16,7 +16,7 @@ tocdepth: 2
 
 ### Fixes
 
-- …
+- Fixed `IndexError` in `FieldArray.characteristic_poly()` and `FieldArray.minimal_poly()` for 1x1 matrices. ([#660](https://github.com/mhostetter/galois/pull/660))
 
 ### Documentation
 
@@ -25,3 +25,4 @@ tocdepth: 2
 ### Contributors
 
 - Matt Hostetter ([@mhostetter](https://github.com/mhostetter))
+- Vincent Gao ([@gaoflow](https://github.com/gaoflow))

--- a/src/galois/_fields/_array.py
+++ b/src/galois/_fields/_array.py
@@ -2364,6 +2364,9 @@ def _poly_det(A: np.ndarray) -> Poly:
     """
     Computes the determinant of a matrix of `Poly` objects.
     """
+    if A.shape == (1, 1):
+        return A[0, 0]
+
     field = A.flatten()[0].field
 
     if A.shape == (2, 2):

--- a/tests/fields/test_arithmetic_methods.py
+++ b/tests/fields/test_arithmetic_methods.py
@@ -98,6 +98,29 @@ def test_minimal_poly_element(field_minimal_poly_element):
         A.minimal_poly()
 
 
+def test_characteristic_minimal_poly_1x1():
+    # A 1x1 matrix [[a]] has characteristic and minimal polynomial x - a. Exercises the
+    # cofactor-expansion base case that previously raised IndexError for 1x1 matrices.
+    fields = [galois.GF(2), galois.GF(5), galois.GF(7), galois.GF(2**4), galois.GF(3**3)]
+    for GF in fields:
+        x = galois.Poly.Identity(GF)
+        for a in GF.elements:
+            A = GF([[a]])
+            c_poly = A.characteristic_poly()
+            m_poly = A.minimal_poly()
+            # det(x*I - [[a]]) = x - a for both the characteristic and minimal polynomial
+            assert c_poly == x - a
+            assert m_poly == x - a
+            assert c_poly.degree == 1 and c_poly.coeffs[0] == GF(1)  # monic, degree 1
+            # Cayley-Hamilton: the matrix is a root of its own characteristic polynomial
+            assert np.array_equal(c_poly(A, elementwise=False), GF.Zeros((1, 1)))
+
+    # The added base case leaves larger matrices unchanged: c(x) = x^2 - tr(A) x + det(A).
+    GF = galois.GF(7)
+    A = GF([[2, 3], [1, 4]])
+    assert A.characteristic_poly() == galois.Poly([1, -np.trace(A), np.linalg.det(A)], field=GF)
+
+
 # def test_minimal_poly_matrix(field_minimal_poly_matrix):
 #     GF, X, Z = field_minimal_poly_matrix["GF"], field_minimal_poly_matrix["X"], field_minimal_poly_matrix["Z"]
 


### PR DESCRIPTION
## Summary

`FieldArray.characteristic_poly()` and `FieldArray.minimal_poly()` both raise `IndexError` on any 1x1 matrix:

```python
import galois
A = galois.GF(7)([[5]])
A.characteristic_poly()   # IndexError: index 0 is out of bounds for axis 0 with size 0
A.minimal_poly()          # same error
```

Both routes reach `_poly_det`, the cofactor-expansion determinant of a matrix of `Poly` objects, which only has a base case for `(2, 2)`. A 1x1 input falls through to the general branch and recurses into an empty `(0, 0)` submatrix, where `A.flatten()[0].field` indexes an empty array. The determinant of `[[a]]` is just `a`, so this adds the missing 1x1 base case; both methods then return `x - a`, the correct characteristic and minimal polynomial of a 1x1 matrix.

Matrices with `n >= 2` are unaffected — the cofactor recursion already bottoms out at the `(2, 2)` base case, and I confirmed `characteristic_poly()`/`minimal_poly()` output is unchanged before and after the fix.

## Type

- [x] Fix (bug / correctness)

## Release notes

- [x] Added entry to `docs/release-notes/unreleased.md`

## Testing

- [x] Added `test_characteristic_minimal_poly_1x1`: both methods on 1x1 matrices over prime and extension fields (GF(2), GF(5), GF(7), GF(2^4), GF(3^3)), asserting the exact `x - a` result and that the matrix satisfies its own characteristic polynomial (Cayley-Hamilton).
- [x] `pytest tests/fields/test_arithmetic_methods.py tests/fields/test_linalg.py` passes (792 tests).

## Backwards compatibility

- [x] No breaking changes
